### PR TITLE
#38: Disable fields when APIKey is not provided

### DIFF
--- a/ncd-calculator/src/__test__/getPublicFasta.test.js
+++ b/ncd-calculator/src/__test__/getPublicFasta.test.js
@@ -18,6 +18,7 @@ import * as path from "node:path";
 const parser = new Parser([]);
 const searchTerm = "buffalo";
 const listSize = 20;
+const apiKey = "secretApiKey"
 
 const getSampleFasta = () => {
     return readFileSync(join(__dirname, "buffaloes_fasta.json"), 'utf-8');
@@ -29,7 +30,7 @@ const ACCESSIONS = SAMPLE_FASTA.map(json => json.acessionNumbers);
 const SEQUENCES = SAMPLE_FASTA.map(json => json.sequence);
 
 test('test fetch fasta IDs for buffalo', async () => {
-    const idsUri = getSequenceIdsBySearchTermUri(searchTerm, listSize);
+    const idsUri = getSequenceIdsBySearchTermUri(searchTerm, listSize, apiKey);
     const response = await fetchWithRetry(getApiResponse, idsUri);
     const json = await parser.parseStringPromise(response);
     const ids = json["eSearchResult"]["IdList"][0]["Id"];
@@ -38,7 +39,7 @@ test('test fetch fasta IDs for buffalo', async () => {
 })
 
 test('test fetch accessions numbers from fasta IDs', async () => {
-    let fastaAccessionNumbersFromIdsUri = getFastaAccessionNumbersFromIdsUri(IDS);
+    let fastaAccessionNumbersFromIdsUri = getFastaAccessionNumbersFromIdsUri(IDS, apiKey);
     let textResponse = await fetchWithRetry(getApiResponse, fastaAccessionNumbersFromIdsUri)
     const accessionNumbers = textResponse.trim().split("\n").map(parseAccessionNumber);
     expect(arraysEqual(accessionNumbers, ACCESSIONS));
@@ -46,14 +47,14 @@ test('test fetch accessions numbers from fasta IDs', async () => {
 
 
 test('test fetch sequence responses from fasta IDs', async () => {
-    const fastaListUri = getFastaListUri(IDS);
+    const fastaListUri = getFastaListUri(IDS, apiKey);
     const sequenceResponse = await fetchWithRetry(getApiResponse, fastaListUri);
     let parsed = parseFasta(sequenceResponse);
     expect(arraysEqual(parsed.contents, SEQUENCES));
 });
 
 test('test fetch fasta list from search term', async () => {
-    let uri = getSequenceIdsBySearchTermUri(searchTerm, listSize);
+    let uri = getSequenceIdsBySearchTermUri(searchTerm, listSize, apiKey);
     let ids = (await fetchWithRetry(getApiResponse, uri)).split(",");
     expect(arraysEqual(ids, IDS));
     let accessionUris = await fetchWithRetry(getFastaAccessionNumbersFromIds, ids);

--- a/ncd-calculator/src/components/FastaSearch.jsx
+++ b/ncd-calculator/src/components/FastaSearch.jsx
@@ -125,7 +125,7 @@ export const FastaSearch = () => {
     }
 
 
-    const performSearch = async (searchTerms, projectionOptions) => {
+    const performSearch = async (searchTerms, projectionOptions, apiKey) => {
         if (emptySearchTerms(searchTerms)) {
             return;
         }
@@ -133,7 +133,7 @@ export const FastaSearch = () => {
         const accessionToSearchTerm = new Map();
         const results = [];
         for (let i = 0; i < searchTerms.length; i++) {
-            const rs = await getSearchResult(searchTerms[i]);
+            const rs = await getSearchResult(searchTerms[i], apiKey);
             if (rs.contents.length !== 0) {
                 results.push(rs);
                 for (let j = 0; j < rs.accessions.length; j++) {
@@ -181,7 +181,7 @@ export const FastaSearch = () => {
                 }
             }
             if (missAccessions.size !== 0) {
-                const missedSequences = await getFastaSequence(Array.from(missAccessions));
+                const missedSequences = await getFastaSequence(Array.from(missAccessions), apiKey);
                 const accessionSeqToCache = {
                     accessions: [],
                     contents: []
@@ -363,7 +363,7 @@ export const FastaSearch = () => {
     }
 
 
-    const getSearchResult = async (searchTerm) => {
+    const getSearchResult = async (searchTerm, apiKey) => {
         const emptyResult = {
             contents: [],
             labels: [],
@@ -394,7 +394,7 @@ export const FastaSearch = () => {
                 cacheHit: true
             }
         } else {
-            const ids = await getSequenceIdsBySearchTerm(searchTerm, 1);
+            const ids = await getSequenceIdsBySearchTerm(searchTerm, 1, apiKey);
             if (ids && ids.length !== 0) {
                 const unfilteredAccessions = await getFastaAccessionNumbersFromIds(ids);
                 const accessions = filterValidAccessionAndParse(unfilteredAccessions);

--- a/ncd-calculator/src/components/ListEditor.jsx
+++ b/ncd-calculator/src/components/ListEditor.jsx
@@ -12,7 +12,7 @@ const ListEditor = ({performSearch}) => {
         CommonName: true,
         FileName: false,
     });
-
+    const [apiKey, setApiKey] = useState('');
 
     const onInputChange = (term) => {
         setSearchTerm(term);
@@ -20,8 +20,8 @@ const ListEditor = ({performSearch}) => {
     }
 
     const onPerformSearch = () => {
-        if (selectedItems.length !== 0) {
-            performSearch(selectedItems, projections);
+        if (!isDisabledByApiKey && selectedItems.length !== 0) {
+            performSearch(selectedItems, projections, apiKey);
         }
     }
 
@@ -33,11 +33,13 @@ const ListEditor = ({performSearch}) => {
         }
     };
 
+    const isDisabledByApiKey = apiKey === null || apiKey.trim() === '';
 
     return (
         <div style={{padding: '20px', width: '100%'}}>
             {/* Main Content - Side by Side Layout */}
-            <div style={{display: 'flex', gap: '24px', flex: 1, width: '60vw'}}>
+            <div
+                style={{display: 'flex', gap: '24px', flex: 1, width: '60vw', pointerEvents: isDisabledByApiKey ? 'none' : 'auto'}}>
                 <div style={{
                     width: '50%',
                     height: '500px',
@@ -55,7 +57,8 @@ const ListEditor = ({performSearch}) => {
                         color: '#1a365d'
                     }}>Search
                         Results</h3>
-                    <div style={{position: 'relative', marginBottom: '20px'}}>
+                    <div
+                        style={{position: 'relative', marginBottom: '20px'}}>
                         <div
                             style={{position: 'absolute', left: '16px', top: '50%', transform: 'translateY(-50%)'}}>
                             <Search size={20} color="#4a5568"/>
@@ -66,14 +69,13 @@ const ListEditor = ({performSearch}) => {
                             onKeyDown={handleKeyDown}
                             onChange={(e) => onInputChange(e.target.value)}
                             placeholder="Search animals..."
+                            className={`${isDisabledByApiKey ? 'bg-gray-300 text-gray-800' : 'bg-white text-black'}`}
                             style={{
                                 width: '100%',
                                 padding: '12px 12px 12px 48px',
                                 border: '2px solid #e2e8f0',
                                 borderRadius: '8px',
                                 fontSize: '1rem',
-                                color: 'black', // Set text color to black
-                                backgroundColor: '#f8fafc',
                                 outline: 'none',
                                 transition: 'border-color 0.2s',
                             }}
@@ -168,22 +170,32 @@ const ListEditor = ({performSearch}) => {
                 </div>
             </div>
 
+            <div className="mb-6 mt-6">
+                <label htmlFor="large-input" className="block mb-2 text-lg font-medium text-gray-900 dark:text-white">Enter API Key</label>
+                <input type="text" id="large-input"
+                       className="block w-full p-4 text-black bg-white border border-gray-300 rounded-lg text-base"
+                       value={apiKey}
+                       onChange={(event) => setApiKey(event.target.value)}
+                />
+            </div>
 
             <div style={{
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'space-between',
                 marginBottom: '24px',
-                marginTop: '24px'
+                marginTop: '24px',
+                pointerEvents: isDisabledByApiKey ? 'none' : 'auto'
             }}>
                 <div style={{display: 'flex', gap: '12px', flexWrap: 'wrap'}}>
                     {Object.entries(projections).map(([key, value]) => (
-                        <label key={key} style={{
+                        <label
+                            className={`${isDisabledByApiKey ? 'bg-gray-300' : (value ? 'bg-blue-200' : 'bg-white')}`}
+                            key={key} style={{
                             display: 'flex',
                             alignItems: 'center',
                             gap: '8px',
                             padding: '8px 16px',
-                            backgroundColor: value ? '#e3f2fd' : 'white',
                             borderRadius: '6px',
                             cursor: 'pointer',
                             border: '1px solid #e2e8f0'
@@ -205,10 +217,9 @@ const ListEditor = ({performSearch}) => {
 
                 <button
                     onClick={onPerformSearch}
+                    className={`${isDisabledByApiKey ? 'bg-gray-300 text-gray-800' : 'bg-blue-600 text-white hover:bg-blue-900'}`}
                     style={{
                         padding: '12px 24px',
-                        backgroundColor: '#3182ce',
-                        color: 'white',
                         fontSize: '1rem',
                         borderRadius: '8px',
                         cursor: 'pointer',
@@ -216,8 +227,6 @@ const ListEditor = ({performSearch}) => {
                         boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
                         transition: 'background-color 0.2s'
                     }}
-                    onMouseEnter={(e) => e.target.style.backgroundColor = '#2b6cb0'}
-                    onMouseLeave={(e) => e.target.style.backgroundColor = '#3182ce'}
                 >
                     Search
                 </button>

--- a/ncd-calculator/src/functions/api.js
+++ b/ncd-calculator/src/functions/api.js
@@ -1,7 +1,6 @@
-export const encodeURIWithApiKey = (uri) => {
-    if (import.meta.env.VITE_NCBI_API_KEY) {
-        return encodeURI(uri + "&api_key" + import.meta.env.VITE_NCBI_API_KEY);
-    } else {
-        return encodeURI(uri);
+export const encodeURIWithApiKey = (uri, apiKey = null) => {
+    if (apiKey) {
+        uri += "&api_key" + apiKey;
     }
+    return encodeURI(uri);
 }

--- a/ncd-calculator/src/functions/getPublicFasta.js
+++ b/ncd-calculator/src/functions/getPublicFasta.js
@@ -11,36 +11,36 @@ export const getApiResponse = async (uri) => {
     return await response.text();
 }
 
-export const getFastaList = async (idList) => {
-    const FETCH_URI = getFastaListUri(idList) ;
+export const getFastaList = async (idList, apiKey) => {
+    const FETCH_URI = getFastaListUri(idList, apiKey) ;
     return await getApiResponseText(FETCH_URI);
 }
 
 
 
-export const getFastaListAndParse = async (idList) => {
-    const FETCH_URI = getFastaListUri(idList) ;
+export const getFastaListAndParse = async (idList, apiKey) => {
+    const FETCH_URI = getFastaListUri(idList, apiKey) ;
     const data = await getApiResponseText(FETCH_URI);
     return parseFasta(data);
 }
 
 
 
-export const getFastaListUri = (idList) => {
+export const getFastaListUri = (idList, apiKey) => {
     const copy = [...idList];
     const ids = copy.join(",");
-    return encodeURIWithApiKey(`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=${ids}&rettype=fasta&retmode=text`);
+    return encodeURIWithApiKey(`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=${ids}&rettype=fasta&retmode=text`, apiKey);
 }
 
-export const getFastaAccessionNumbersFromIdsUri = (idList) => {
+export const getFastaAccessionNumbersFromIdsUri = (idList, apiKey) => {
     if (typeof idList !== 'string') {
         idList = idList.join(",");
     }
-    return encodeURIWithApiKey(`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${idList}&rettype=acc`);
+    return encodeURIWithApiKey(`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${idList}&rettype=acc`, apiKey);
 }
 
-export const getFastaAccessionNumbersFromIds = async (idList) => {
-    const FETCH_URI = getFastaAccessionNumbersFromIdsUri(idList) ;
+export const getFastaAccessionNumbersFromIds = async (idList, apiKey) => {
+    const FETCH_URI = getFastaAccessionNumbersFromIdsUri(idList, apiKey) ;
     let accessions = await getApiResponseText(FETCH_URI);
     if (accessions && accessions !== '') {
         return accessions.split("\n").filter(accession => accession != null);
@@ -50,13 +50,13 @@ export const getFastaAccessionNumbersFromIds = async (idList) => {
 
 
 
-export const getSequenceIdsBySearchTermUri = (searchTerm, numItems) => {
+export const getSequenceIdsBySearchTermUri = (searchTerm, numItems, apiKey) => {
     searchTerm = searchTerm.trim() + " AND mitochondrion[title] AND genome[title]";
-    return encodeURIWithApiKey(`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nuccore&term=${searchTerm}&retmode=text&rettype=fasta&retmax=${numItems}`);
+    return encodeURIWithApiKey(`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nuccore&term=${searchTerm}&retmode=text&rettype=fasta&retmax=${numItems}`, apiKey);
 }
 
-export const getSequenceIdsBySearchTerm = async (searchTerm, numItems) => {
-    const ID_LIST_URI = getSequenceIdsBySearchTermUri(searchTerm, numItems)
+export const getSequenceIdsBySearchTerm = async (searchTerm, numItems, apiKey) => {
+    const ID_LIST_URI = getSequenceIdsBySearchTermUri(searchTerm, numItems, apiKey)
     let idList = [];
     const searchResult = await getApiResponseText(ID_LIST_URI);
     const parser = new DOMParser();

--- a/ncd-calculator/src/functions/getPublicGenbank.js
+++ b/ncd-calculator/src/functions/getPublicGenbank.js
@@ -121,10 +121,10 @@ const formatResponse = (sequences, labels) => {
     };
 };
 
-const getGenbankListUri = (ids) => {
+const getGenbankListUri = (ids, apiKey) => {
     const IDS = ids.join(",");
     return encodeURIWithApiKey(
-        `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=${IDS}&rettype=genbank&retmode=text`
+        `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=${IDS}&rettype=genbank&retmode=text`, apiKey
     );
 };
 


### PR DESCRIPTION
Create a FASTA mode selector within the GenBank fetch component
Initially, set the selector to be greyed out (ghosted) and disabled
Implement logic to monitor the user's GenBank API key input
When a valid API key is detected, enable the FASTA mode selector

Note: the default value for api_key is null for now