### PR TITLE
fix(workers): make compression startup resilient

### DIFF
--- a/ncd-calculator/README.md
+++ b/ncd-calculator/README.md
@@ -30,6 +30,7 @@ Pair compression is explicitly order-dependent. The worker first constructs the 
 ```bash
 npm run build
 npm run graphviz:verify-dev
+npm run workers:verify-dev
 npm run lint
 npm run test
 npm run typecheck
@@ -44,7 +45,7 @@ After changing dependencies or switching branches while the development server i
 npm run dev -- --force
 ```
 
-The planar-tree interface reports initialization failures and offers **Retry renderer**. The shared loader deduplicates concurrent initialization and clears failed attempts before retrying.
+The planar-tree interface reports initialization failures and offers **Retry renderer**. The shared loader deduplicates concurrent initialization and clears failed attempts before retrying. Compression workers use Vite's native `new Worker(new URL(...))` transform rather than dynamically importing `?worker` wrapper modules; `workers:verify-dev` transforms and serves both entries in middleware mode so development-only worker regressions fail before a build. The selected compressor starts lazily when a calculation begins—there is no competing ZSTD prewarm—and has a 30-second cold-start window. Native worker load and message-decoding failures are reported immediately and failed workers are terminated.
 
 Focused interface coverage is in `src/__test__/landingPage.test.tsx` and `src/__test__/workbench.test.tsx`.
 

--- a/ncd-calculator/package.json
+++ b/ncd-calculator/package.json
@@ -8,13 +8,14 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run graphviz:verify-dev && npm run udhr:verify && vite build && node scripts/verify-production-bundle.mjs",
+    "build": "npm run graphviz:verify-dev && npm run workers:verify-dev && npm run udhr:verify && vite build && node scripts/verify-production-bundle.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "debug": "vite --debug",
     "test": "vitest --run",
     "typecheck": "tsc --noEmit",
     "graphviz:verify-dev": "node scripts/verify-dev-graphviz.mjs",
+    "workers:verify-dev": "node scripts/verify-dev-compression-workers.mjs",
     "udhr:audit": "node scripts/build-udhr-corpus.mjs --audit-only",
     "udhr:refresh": "node scripts/build-udhr-corpus.mjs",
     "udhr:verify": "node scripts/verify-udhr-corpus.mjs"

--- a/ncd-calculator/scripts/verify-dev-compression-workers.mjs
+++ b/ncd-calculator/scripts/verify-dev-compression-workers.mjs
@@ -1,0 +1,46 @@
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {createServer} from "vite";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const projectDirectory = path.resolve(scriptDirectory, "..");
+const serviceModule = "/src/services/CompressionService.ts";
+const workers = ["lzmaWorker", "zstdWorker"];
+
+const server = await createServer({
+    root: projectDirectory,
+    configFile: path.join(projectDirectory, "vite.config.ts"),
+    logLevel: "error",
+    appType: "custom",
+    server: {
+        middlewareMode: true,
+        hmr: false,
+    },
+});
+
+try {
+    const transformedService = await server.transformRequest(serviceModule);
+    if (!transformedService?.code) {
+        throw new Error(`Vite did not transform ${serviceModule}.`);
+    }
+    if (/import\([^)]*\?worker["']/u.test(transformedService.code)) {
+        throw new Error("CompressionService reintroduced a fragile dynamic ?worker module import.");
+    }
+
+    for (const worker of workers) {
+        const workerUrl = transformedService.code.match(
+            new RegExp(`"([^"]*${worker}\\.ts\\?worker_file&type=module)"`, "u"),
+        )?.[1];
+        if (!workerUrl) {
+            throw new Error(`${worker} is not registered through Vite's native Worker URL transform.`);
+        }
+        const transformedWorker = await server.transformRequest(workerUrl);
+        if (!transformedWorker?.code || !transformedWorker.code.includes("postMessage")) {
+            throw new Error(`Vite could not serve a usable ${worker} module: ${workerUrl}`);
+        }
+    }
+
+    console.log("Development compression-worker verification passed: LZMA and ZSTD use native worker URLs.");
+} finally {
+    await server.close();
+}

--- a/ncd-calculator/src/__test__/compressionServiceInitialization.test.ts
+++ b/ncd-calculator/src/__test__/compressionServiceInitialization.test.ts
@@ -1,0 +1,92 @@
+import {describe, expect, test, vi} from "vitest";
+import {CompressionService} from "../services/CompressionService";
+import type {WorkerFactory} from "../services/CompressionService";
+
+class ControlledWorker extends EventTarget {
+    readonly terminate = vi.fn();
+    readonly postMessage = vi.fn();
+}
+
+const serviceWithWorker = (worker: ControlledWorker, timeout: number): CompressionService => {
+    const factory: WorkerFactory = vi.fn(async () => worker as unknown as Worker);
+    return CompressionService.getInstance(factory, "lzma", timeout);
+};
+
+describe("CompressionService worker initialization", () => {
+    test("allows a worker to become ready within the configured cold-start window", async () => {
+        const worker = new ControlledWorker();
+        const service = serviceWithWorker(worker, 100);
+        setTimeout(() => worker.dispatchEvent(new MessageEvent("message", {
+            data: {type: "ready", message: "ready"},
+        })), 20);
+
+        await expect(service.initialize("lzma")).resolves.toBeUndefined();
+        expect(service.hasActiveWorker()).toBe(true);
+        expect(worker.terminate).not.toHaveBeenCalled();
+        service.terminate();
+    });
+
+    test("reports a native worker load error immediately and terminates the worker", async () => {
+        const worker = new ControlledWorker();
+        const service = serviceWithWorker(worker, 1_000);
+        setTimeout(() => worker.dispatchEvent(new ErrorEvent("error", {
+            message: "module fetch failed",
+            cancelable: true,
+        })), 0);
+
+        await expect(service.initialize("lzma")).rejects.toThrow(
+            "Compression worker failed to start: module fetch failed.",
+        );
+        expect(worker.terminate).toHaveBeenCalledOnce();
+        expect(service.hasActiveWorker()).toBe(false);
+    });
+
+    test("uses a readable timeout error and terminates an unresponsive worker", async () => {
+        const worker = new ControlledWorker();
+        const service = serviceWithWorker(worker, 10);
+
+        await expect(service.initialize("lzma")).rejects.toThrow(
+            "Compression worker did not become ready within 1 seconds.",
+        );
+        expect(worker.terminate).toHaveBeenCalledOnce();
+        expect(service.hasActiveWorker()).toBe(false);
+    });
+
+    test("reports an undecodable worker response without waiting for the timeout", async () => {
+        const worker = new ControlledWorker();
+        const service = serviceWithWorker(worker, 1_000);
+        setTimeout(() => worker.dispatchEvent(new MessageEvent("messageerror")), 0);
+
+        await expect(service.initialize("lzma")).rejects.toThrow(
+            "Compression worker failed to start because its response could not be decoded.",
+        );
+        expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+
+    test("terminates a worker that crashes during computation", async () => {
+        const worker = new ControlledWorker();
+        const service = serviceWithWorker(worker, 100);
+        setTimeout(() => worker.dispatchEvent(new MessageEvent("message", {
+            data: {type: "ready", message: "ready"},
+        })), 0);
+        await service.initialize("lzma");
+
+        const computation = service.processContent({
+            labels: ["a", "b"],
+            contents: ["aaaa", "bbbb"],
+            contentKeys: ["a-key", "b-key"],
+            cachedSizes: undefined,
+            algorithm: "lzma",
+        });
+        worker.dispatchEvent(new ErrorEvent("error", {
+            message: "worker crashed",
+            cancelable: true,
+        }));
+
+        await expect(computation).rejects.toThrow(
+            "Compression worker failed during computation: worker crashed.",
+        );
+        expect(worker.terminate).toHaveBeenCalledOnce();
+        expect(service.hasActiveWorker()).toBe(false);
+    });
+});

--- a/ncd-calculator/src/__test__/workbench.test.tsx
+++ b/ncd-calculator/src/__test__/workbench.test.tsx
@@ -9,9 +9,20 @@ import {getWorkbenchExampleItems} from "../components/workbenchExamples";
 import {FASTA, LANGUAGE} from "../constants/modalConstants";
 import {STORAGE_VERSION, STORAGE_VERSION_NAME} from "../cache/LocalStorageKeyManager";
 
+const compressionWorkerLifecycleMocks = vi.hoisted(() => ({
+    initialize: vi.fn(),
+    terminate: vi.fn(),
+}));
+
+
 vi.mock("../services/CompressionService", () => ({
     CompressionService: {
-        getInstance: () => ({initialize: vi.fn(), terminate: vi.fn()}),
+        getInstance: () => compressionWorkerLifecycleMocks,
+        getAvailableAlgorithms: () => ["lzma", "zstd"],
+        getAlgorithmInfo: (algorithm: string) => ({
+            maxSize: algorithm === "lzma" ? 2 * 1024 * 1024 : 128 * 1024 * 1024,
+            description: `${algorithm} compression`,
+        }),
     },
 }));
 
@@ -131,6 +142,23 @@ describe("NCD workbench", () => {
         const showSimilarity = screen.getByRole("button", {name: "Show Similarity"});
         expect(showSimilarity.closest(".workbench-actions")).not.toBeNull();
         expect(showSimilarity.closest(".workbench-sourcebar")).toBeNull();
+    });
+
+    test("does not prewarm an unused compression worker", () => {
+        compressionWorkerLifecycleMocks.initialize.mockClear();
+        render(
+            <MemoryRouter>
+                <ListEditor
+                    onComputedNcdInput={vi.fn()}
+                    setIsLoading={vi.fn()}
+                    resetDisplay={vi.fn()}
+                    setOpenLogin={vi.fn()}
+                    authenticated={false}
+                />
+            </MemoryRouter>
+        );
+
+        expect(compressionWorkerLifecycleMocks.initialize).not.toHaveBeenCalled();
     });
 
     test("upgrades saved UDHR identifiers to canonical language names", async () => {

--- a/ncd-calculator/src/components/ListEditor.tsx
+++ b/ncd-calculator/src/components/ListEditor.tsx
@@ -27,7 +27,6 @@ import {LocalStorageKeyManager, LocalStorageKeys} from "../cache/LocalStorageKey
 import {getFastaSequences} from "../functions/getPublicGenbank";
 import {FASTA, FILE_UPLOAD, LANGUAGE} from "../constants/modalConstants";
 import {useSearchParams} from "react-router-dom";
-import {CompressionService} from "@/services/CompressionService";
 import {NCDImportFormat} from "@/types/ncd";
 import createGraph from "@/functions/graphExport.ts";
 import {saveAs} from "file-saver";
@@ -223,7 +222,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	// Constants and Refs
 	const MIN_ITEMS = 4;
 	const localStorageManager = LocalStorageKeyManager.getInstance();
-	const compressionServiceRef = useRef(CompressionService.getInstance());
 	const [, setSearchParams] = useSearchParams();
 	
 	// Computed values
@@ -256,12 +254,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 			setSelectedItems([]);
 		}
 		
-		// Initialize compression service
-		compressionServiceRef.current.initialize();
-		
-		return () => {
-			compressionServiceRef.current.terminate();
-		};
 	}, []);
 	
 	// Update search mode when initialSearchMode changes

--- a/ncd-calculator/src/services/CompressionService.ts
+++ b/ncd-calculator/src/services/CompressionService.ts
@@ -23,6 +23,7 @@ export type WorkerFactory = (algorithm: CompressionAlgorithm) => Promise<Worker>
  */
 export class CompressionService {
 	private static instance: CompressionService;
+	private static readonly DEFAULT_INITIALIZATION_TIMEOUT_MS = 30_000;
 	
 	// Configuration constants for compression algorithms
 	private static readonly MAX_SIZES = {
@@ -47,7 +48,7 @@ export class CompressionService {
 	private workerFactory: WorkerFactory;
 	
 	// Timeout for worker initialization in milliseconds
-	private initializationTimeout: number = 10000;
+	private initializationTimeout: number = CompressionService.DEFAULT_INITIALIZATION_TIMEOUT_MS;
 	
 	/**
 	 * Private constructor that accepts optional worker factory and default algorithm
@@ -59,7 +60,7 @@ export class CompressionService {
 	private constructor(
 		workerFactory?: WorkerFactory,
 		defaultAlgorithm: CompressionAlgorithm = "zstd",
-		timeout: number = 10000
+		timeout: number = CompressionService.DEFAULT_INITIALIZATION_TIMEOUT_MS
 	) {
 		this.workerFactory = workerFactory || this.defaultWorkerFactory.bind(this);
 		this.initializationTimeout = timeout;
@@ -275,13 +276,15 @@ export class CompressionService {
 	private async defaultWorkerFactory(algorithm: CompressionAlgorithm): Promise<Worker> {
 		switch (algorithm) {
 			case "lzma":
-				// @ts-ignore
-				const LzmaWorkerModule = await import("../workers/lzmaWorker?worker");
-				return new LzmaWorkerModule.default();
+				return new Worker(
+					new URL("../workers/lzmaWorker.ts", import.meta.url),
+					{type: "module", name: "lzma-compression"},
+				);
 			case "zstd":
-				// @ts-ignore
-				const ZstdWorkerModule = await import("../workers/zstdWorker?worker");
-				return new ZstdWorkerModule.default();
+				return new Worker(
+					new URL("../workers/zstdWorker.ts", import.meta.url),
+					{type: "module", name: "zstd-compression"},
+				);
 			default:
 				throw new Error(`Unsupported compression algorithm: ${algorithm}`);
 		}
@@ -307,6 +310,7 @@ export class CompressionService {
 			console.log(`Worker for algorithm: ${this.currentAlgorithm} is ready`);
 		} catch (error) {
 			console.error(`Failed to initialize ${algorithm} worker:`, error);
+			this.worker?.terminate();
 			this.worker = null;
 			this.currentAlgorithm = null;
 			throw error;
@@ -329,9 +333,10 @@ export class CompressionService {
 		try {
 			await this.listenForWorkerReady(abortController.signal);
 		} catch (error) {
-			console.log(error);
 			if (error instanceof DOMException && error.name === 'AbortError') {
-				throw new Error(`Worker initialization timed out after ${this.initializationTimeout}ms`);
+				throw new Error(
+					`Compression worker did not become ready within ${Math.ceil(this.initializationTimeout / 1000)} seconds.`
+				);
 			}
 			throw error;
 		} finally {
@@ -347,6 +352,11 @@ export class CompressionService {
 	 */
 	private async listenForWorkerReady(signal: AbortSignal): Promise<void> {
 		return new Promise((resolve, reject) => {
+			const worker = this.worker;
+			if (!worker) {
+				reject(new Error("Compression worker is unavailable."));
+				return;
+			}
 			const handleMessage = (e: MessageEvent<WorkerMessage>) => {
 				if (e.data.type === "ready") {
 					cleanup();
@@ -356,9 +366,23 @@ export class CompressionService {
 					reject(new Error(e.data.message));
 				}
 			};
+
+			const handleError = (event: ErrorEvent) => {
+				event.preventDefault();
+				cleanup();
+				const detail = event.message?.trim() || "the worker script could not be loaded";
+				reject(new Error(`Compression worker failed to start: ${detail}.`));
+			};
+
+			const handleMessageError = () => {
+				cleanup();
+				reject(new Error("Compression worker failed to start because its response could not be decoded."));
+			};
 			
 			const cleanup = () => {
-				this.worker?.removeEventListener("message", handleMessage);
+				worker.removeEventListener("message", handleMessage);
+				worker.removeEventListener("error", handleError);
+				worker.removeEventListener("messageerror", handleMessageError);
 				signal.removeEventListener("abort", handleAbort);
 			};
 			
@@ -367,7 +391,9 @@ export class CompressionService {
 				reject(new DOMException("Aborted", "AbortError"));
 			};
 			
-			this.worker?.addEventListener("message", handleMessage);
+			worker.addEventListener("message", handleMessage);
+			worker.addEventListener("error", handleError);
+			worker.addEventListener("messageerror", handleMessageError);
 			signal.addEventListener("abort", handleAbort);
 		});
 	}
@@ -384,6 +410,11 @@ export class CompressionService {
 		onProgress?: (message: WorkerMessage) => void
 	): Promise<WorkerResultMessage> {
 		return new Promise((resolve, reject) => {
+			const worker = this.worker;
+			if (!worker) {
+				reject(new Error("Compression worker is unavailable."));
+				return;
+			}
 			const handleMessage = (e: MessageEvent<WorkerMessage>) => {
 				const message = e.data;
 				switch (message.type) {
@@ -401,13 +432,33 @@ export class CompressionService {
 						break;
 				}
 			};
-			
-			const cleanup = () => {
-				this.worker?.removeEventListener("message", handleMessage);
+
+			const handleError = (event: ErrorEvent) => {
+				event.preventDefault();
+				cleanup();
+				if (this.worker === worker) this.terminate();
+				else worker.terminate();
+				const detail = event.message?.trim() || "the worker stopped unexpectedly";
+				reject(new Error(`Compression worker failed during computation: ${detail}.`));
+			};
+
+			const handleMessageError = () => {
+				cleanup();
+				if (this.worker === worker) this.terminate();
+				else worker.terminate();
+				reject(new Error("Compression worker returned a response that could not be decoded."));
 			};
 			
-			this.worker?.addEventListener("message", handleMessage);
-			this.worker?.postMessage(input);
+			const cleanup = () => {
+				worker.removeEventListener("message", handleMessage);
+				worker.removeEventListener("error", handleError);
+				worker.removeEventListener("messageerror", handleMessageError);
+			};
+			
+			worker.addEventListener("message", handleMessage);
+			worker.addEventListener("error", handleError);
+			worker.addEventListener("messageerror", handleMessageError);
+			worker.postMessage(input);
 		});
 	}
 	


### PR DESCRIPTION
## Summary

Fix compression-worker startup failures that appeared as either a failed dynamic module fetch or a generic 10-second initialization timeout.

The PR is intentionally limited to compression worker loading, lifecycle handling, its regression tests, and directly related documentation. It does not include the local astronomy or GenBank pipeline work.

## Root cause

The calculator loaded Vite worker wrappers through dynamic `?worker` imports. During development, a cold Vite transform or stale dependency URL could make that wrapper module unavailable. The readiness path listened only for worker messages, so native script-loading and message-decoding failures were hidden until the timeout expired.

The workbench also initialized the default ZSTD worker when the input editor mounted. A calculation could then request LZMA from the same singleton, producing an unnecessary cold-start race between two compressors.

## Changes

- Instantiate LZMA and ZSTD with Vite native module-worker URLs using `new Worker(new URL(..., import.meta.url))`.
- Initialize only the compressor selected for the calculation; remove the unused ZSTD prewarm from the input editor.
- Use a bounded 30-second cold-start window to accommodate the first development transform and WASM initialization.
- Report native worker load errors and undecodable worker messages immediately.
- Remove listeners and terminate failed workers so retries begin from a clean state.
- Handle native worker crashes during computation and clear the unusable singleton worker.
- Add a Vite middleware verifier that transforms the service, resolves both worker entries, and rejects reintroduction of dynamic `?worker` wrapper imports.
- Run the worker verifier as part of the production build.
- Document startup behavior, recovery, and the development verification command.

## User impact

Cold development starts no longer fail merely because Vite needs more than 10 seconds to prepare a compression worker. Real loading or decoding failures are shown promptly instead of being mislabeled as timeouts. Subsequent attempts do not reuse a broken worker.

The NCD definition, directed pair-compression matrix, compressor selection rules, corpus data, and QSearch behavior are unchanged.

## Validation

Validated from a clean worktree at commit `071904c`:

- `npm test -- src/__test__/compressionServiceInitialization.test.ts src/__test__/workbench.test.tsx` — 14 tests passed.
- `npm run build` — passed, including the development Graphviz verifier, both compression-worker transforms, all 501 UDHR corpus records, the Vite production build, and production bundle verification.
- `git diff --cached --check` — passed before commit.

The build retains existing non-blocking Vite deprecation, browser-externalization, and large-chunk warnings.
