### PR TITLE
feat(genbank): add verified sequence retrieval pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ https://x.com/cilibrar/status/1868028637821481347
 Based on the paper [Clustering by Compression](https://homepages.cwi.nl/~paulv/papers/cluster.pdf) by Cilibrasi and Vitányi
 
 ### Development environment
-##### Config the API key for using NCBI APIs
+##### Configure NCBI E-utilities
 1. Go to: https://account.ncbi.nlm.nih.gov/settings/ > *Account Settings*
 2. In the *API Key Management* section at the bottom, take the API key
-##### Add ENV variables for `ncd-calculator`:
+##### Add environment variables for `ncd-calculator`:
 ```
 cd ncd-calculator
 ```
@@ -27,7 +27,6 @@ cd ncd-calculator
 ```
 2. Create environment variables in .env file:
 ```
-VITE_NCBI_API_KEY=<XXX-API-KEY-FROM-NCBI>
 VITE_BACKEND_BASE_URL=<BACKEND-SERVER-DOMAIN> (i.e. https://openscienceresearchpark.com/api)
 ```
 3. Running commands
@@ -60,14 +59,15 @@ GOOGLE_CLIENT_SECRET=<GOOGLE_CLIENT_SECRET>
 GITHUB_CLIENT_ID=<GITHUB_CLIENT_ID>
 GITHUB_CLIENT_SECRET=<GITHUB_CLIENT_SECRET>
 
-GENBANK_API_KEY_1=<GENBANK_SHARED_API_KEY_1>
-GENBANK_API_KEY_2=<GENBANK_SHARED_API_KEY_2>
-GENBANK_API_KEY_3=<GENBANK_SHARED_API_KEY_3>
+GENBANK_API_KEY=<NCBI_API_KEY>
+NCBI_EMAIL=<MAINTAINER_EMAIL>
 
 FRONTEND_BASE_URL=<FRONTEND_BASE_URL> (i.e. https://openscienceresearchpark.com)
 BASE_URL=<BACKEND_BASE_URL> (i.e. https://openscienceresearchpark.com/api)
 PORT=3001
 ```
+
+The API key is kept on the backend and must not be exposed through a `VITE_` variable. NCBI permits one API key per account. Without a key, the backend automatically uses the documented three-request-per-second limit; with a key it uses ten requests per second. `NCBI_EMAIL` identifies the maintainer to NCBI for operational contact.
 
 ##### Start up all services:
 Each sub-project has their own respective Dockerfile. All running by the `docker-compose.yml` in the root folder. Run this to start all services:

--- a/complearn-genbank/__tests__/ncbiClient.test.ts
+++ b/complearn-genbank/__tests__/ncbiClient.test.ts
@@ -1,0 +1,53 @@
+jest.mock("../configurations/envLoader", () => ({
+    __esModule: true,
+    default: {GENBANK_API_KEY: "server-secret", NCBI_EMAIL: "research@example.org"},
+}));
+
+import axios from "axios";
+import {NcbiRequestScheduler, prepareNcbiUrl} from "../genbank/ncbiClient";
+
+describe("NCBI request validation", () => {
+    test("pins the E-utilities host and replaces client credentials", () => {
+        const url = new URL(prepareNcbiUrl(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=nuccore&id=42&api_key=attacker",
+        ));
+        expect(url.searchParams.get("api_key")).toBe("server-secret");
+        expect(url.searchParams.get("email")).toBe("research@example.org");
+        expect(url.searchParams.get("tool")).toBe("complearn-ncd");
+    });
+
+    test.each([
+        "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nuccore",
+        "https://example.org/entrez/eutils/esearch.fcgi?db=nuccore",
+        "https://eutils.ncbi.nlm.nih.gov/private?db=nuccore",
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=protein",
+    ])("rejects an unsafe target: %s", target => {
+        expect(() => prepareNcbiUrl(target)).toThrow();
+    });
+
+    test("spaces concurrent upstream requests according to the shared rate budget", async () => {
+        jest.useFakeTimers();
+        const request = jest.spyOn(axios, "request").mockResolvedValue({
+            data: "ok",
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            config: {headers: {}},
+        });
+        const scheduler = new NcbiRequestScheduler(2);
+
+        const first = scheduler.request({url: "https://example.test/first"});
+        const second = scheduler.request({url: "https://example.test/second"});
+        await jest.advanceTimersByTimeAsync(0);
+        expect(request).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(499);
+        expect(request).toHaveBeenCalledTimes(1);
+        await jest.advanceTimersByTimeAsync(1);
+        await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+        expect(request).toHaveBeenCalledTimes(2);
+
+        request.mockRestore();
+        jest.useRealTimers();
+    });
+});

--- a/complearn-genbank/configurations/envLoader.ts
+++ b/complearn-genbank/configurations/envLoader.ts
@@ -16,9 +16,10 @@ const ENV_LOADER = {
     GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || "",
     GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET || "",
 
-    GENBANK_API_KEY_1: process.env.GENBANK_API_KEY_1 || "",
-    GENBANK_API_KEY_2: process.env.GENBANK_API_KEY_2 || "",
-    GENBANK_API_KEY_3: process.env.GENBANK_API_KEY_3 || "",
+    // NCBI permits one API key per account. Keep a single configured key so
+    // deployments do not imply that round-robin key rotation increases quota.
+    GENBANK_API_KEY: process.env.GENBANK_API_KEY || process.env.GENBANK_API_KEY_1 || "",
+    NCBI_EMAIL: process.env.NCBI_EMAIL || "",
 
     FRONTEND_BASE_URL: process.env.FRONTEND_BASE_URL || "",
     BASE_URL: process.env.BASE_URL || "",

--- a/complearn-genbank/genbank/genbankUtils.ts
+++ b/complearn-genbank/genbank/genbankUtils.ts
@@ -8,13 +8,12 @@ export const ALLOWED_GENBANK_HOSTNAMES: Set<GenBankHostName> = new Set(Array.fro
 
 
 // Invalid URL might throw an exception TypeError: Invalid URL
-export const addApiKey = (httpVerb: string, uri: clURL, apiKey: string) => {
+export const addApiKey = (_httpVerb: string, uri: clURL, apiKey: string) => {
     const url = new URL(uri);
-    const params = url.searchParams;
-    params.append("api_key", apiKey);
+    if (apiKey) url.searchParams.set("api_key", apiKey);
     return url.toString() as clURL;
 }
 
-export const isGenbankHostname = (hostname: clHostname): boolean => {
+export const isGenbankHostname = (hostname: clHostname | string): boolean => {
     return ALLOWED_GENBANK_HOSTNAMES.has(hostname as GenBankHostName);
 }

--- a/complearn-genbank/genbank/ncbiClient.ts
+++ b/complearn-genbank/genbank/ncbiClient.ts
@@ -1,0 +1,120 @@
+import axios, {AxiosError, AxiosRequestConfig, AxiosResponse} from "axios";
+import ENV_LOADER from "../configurations/envLoader";
+import {clURL} from "../commonTypes/clURL";
+
+const MAX_PENDING_REQUESTS = 256;
+const MAX_CONCURRENT_REQUESTS = 4;
+const MAX_ATTEMPTS = 4;
+const DEFAULT_RETRY_MS = 500;
+
+const wait = (milliseconds: number): Promise<void> => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+export class NcbiQueueFullError extends Error {}
+
+export const prepareNcbiUrl = (rawUrl: string): clURL => {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "https:" || url.hostname !== "eutils.ncbi.nlm.nih.gov") {
+        throw new Error("Only the NCBI E-utilities HTTPS endpoint is allowed.");
+    }
+    const endpoint = url.pathname.split("/").at(-1);
+    if (!url.pathname.startsWith("/entrez/eutils/") || !endpoint || ![
+        "esearch.fcgi",
+        "esummary.fcgi",
+        "efetch.fcgi",
+    ].includes(endpoint)) {
+        throw new Error("Invalid NCBI E-utilities path.");
+    }
+    const database = url.searchParams.get("db");
+    if (database && !["nuccore", "nucleotide", "taxonomy"].includes(database)) {
+        throw new Error("Unsupported NCBI database.");
+    }
+    url.searchParams.delete("api_key");
+    url.searchParams.set("tool", "complearn-ncd");
+    if (ENV_LOADER.NCBI_EMAIL) url.searchParams.set("email", ENV_LOADER.NCBI_EMAIL);
+    if (ENV_LOADER.GENBANK_API_KEY) url.searchParams.set("api_key", ENV_LOADER.GENBANK_API_KEY);
+    return url.toString() as clURL;
+};
+
+const retryDelay = (error: AxiosError, attempt: number): number => {
+    const retryAfter = error.response?.headers["retry-after"];
+    const seconds = Number.parseInt(String(retryAfter ?? ""), 10);
+    if (Number.isFinite(seconds) && seconds > 0) return Math.min(seconds * 1000, 30_000);
+    return DEFAULT_RETRY_MS * (2 ** (attempt - 1));
+};
+
+const isRetryable = (error: unknown): error is AxiosError => {
+    if (!axios.isAxiosError(error)) return false;
+    const status = error.response?.status;
+    return status === undefined || status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
+};
+
+export class NcbiRequestScheduler {
+    private tail: Promise<void> = Promise.resolve();
+    private pending = 0;
+    private active = 0;
+    private readonly slotWaiters: Array<() => void> = [];
+    private nextStart = 0;
+    private readonly intervalMs: number;
+
+    constructor(requestsPerSecond = ENV_LOADER.GENBANK_API_KEY ? 10 : 3) {
+        this.intervalMs = Math.ceil(1000 / requestsPerSecond);
+    }
+
+    private async acquireSlot(): Promise<void> {
+        if (this.active >= MAX_CONCURRENT_REQUESTS) {
+            await new Promise<void>(resolve => this.slotWaiters.push(resolve));
+        }
+        this.active += 1;
+    }
+
+    private releaseSlot(): void {
+        this.active -= 1;
+        this.slotWaiters.shift()?.();
+    }
+
+    private async waitForRateSlot(): Promise<void> {
+        let release!: () => void;
+        const previous = this.tail;
+        this.tail = new Promise<void>(resolve => { release = resolve; });
+        await previous;
+        try {
+            const delay = Math.max(0, this.nextStart - Date.now());
+            if (delay > 0) await wait(delay);
+            this.nextStart = Date.now() + this.intervalMs;
+        } finally {
+            release();
+        }
+    }
+
+    async request<T>(config: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+        if (this.pending >= MAX_PENDING_REQUESTS) throw new NcbiQueueFullError("The NCBI request queue is full. Try again shortly.");
+        this.pending += 1;
+
+        await this.acquireSlot();
+
+        try {
+            for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+                try {
+                    // Retries consume the same NCBI rate budget as first attempts.
+                    // Re-enter the shared start queue before every upstream call.
+                    await this.waitForRateSlot();
+                    return await axios.request<T>({
+                        ...config,
+                        timeout: 30_000,
+                        maxContentLength: 160 * 1024 * 1024,
+                        maxBodyLength: 2 * 1024 * 1024,
+                    });
+                } catch (error) {
+                    if (attempt === MAX_ATTEMPTS || !isRetryable(error)) throw error;
+                    await wait(retryDelay(error, attempt));
+                }
+            }
+            throw new Error("NCBI request retry loop ended unexpectedly.");
+        } finally {
+            this.pending -= 1;
+            this.releaseSlot();
+        }
+    }
+}
+
+export const ncbiRequestScheduler = new NcbiRequestScheduler();

--- a/complearn-genbank/routes/external.ts
+++ b/complearn-genbank/routes/external.ts
@@ -1,77 +1,60 @@
-import express, { Request, Response } from "express";
+import express, {Request, Response} from "express";
 import axios from "axios";
-import ENV_LOADER from "../configurations/envLoader";
 import logger from "../configurations/logger";
+import {isGenbankHostname} from "../genbank/genbankUtils";
 import {
-  addApiKey,
-  GenBankHostName,
-  isGenbankHostname,
-} from "../genbank/genbankUtils";
-import { clURL } from "../commonTypes/clURL";
+  NcbiQueueFullError,
+  ncbiRequestScheduler,
+  prepareNcbiUrl,
+} from "../genbank/ncbiClient";
 
 const router = express.Router();
 
-let apiKeyIndex = 0;
-
-const apiKeys = [
-  ENV_LOADER.GENBANK_API_KEY_1,
-  ENV_LOADER.GENBANK_API_KEY_2,
-  ENV_LOADER.GENBANK_API_KEY_3,
-];
-
-function getNextApiKey() {
-  const apiKey = apiKeys[apiKeyIndex];
-  apiKeyIndex = (apiKeyIndex + 1) % apiKeys.length;
-  return apiKey;
-}
-
 router.post("/forward", async (req: Request, res: Response): Promise<any> => {
   try {
-    const {
-      externalUrl = "",
-      method = "GET",
-      body = null,
-      responseType = "json",
-      responseHeaders = {},
-    } = req.body;
-
-    if (!externalUrl) {
-      return res.status(400).send({ error: "Target URL is required" });
-    }
+    const externalUrl = typeof req.body?.externalUrl === "string" ? req.body.externalUrl : "";
+    if (!externalUrl) return res.status(400).json({error: "Target URL is required"});
 
     const parsedUrl = new URL(externalUrl);
-    console.log("hostname: " + parsedUrl.hostname);
-    if (!isGenbankHostname(parsedUrl.hostname as GenBankHostName)) {
-      throw new Error(`Invalid hostname: ${parsedUrl.hostname}`);
+    if (!isGenbankHostname(parsedUrl.hostname)) {
+      return res.status(400).json({error: "Target host is not allowed"});
     }
-    const urlWithApiKey: clURL = addApiKey(
-      "GET",
-      parsedUrl.toString() as clURL,
-      getNextApiKey()
-    );
+    if (parsedUrl.hostname !== "eutils.ncbi.nlm.nih.gov") {
+      return res.status(400).json({error: "This endpoint only proxies NCBI E-utilities requests"});
+    }
 
-    Object.entries(responseHeaders).forEach(([key, value]: [any, any]) => {
-      res.setHeader(key, value);
+    const safeUrl = prepareNcbiUrl(externalUrl);
+    logger.info({requestId: req.requestId, message: "Forwarding NCBI E-utilities request", path: parsedUrl.pathname});
+    const response = await ncbiRequestScheduler.request({
+      url: safeUrl,
+      method: "GET",
+      responseType: "text",
+      transformResponse: [(value: string) => value],
+      validateStatus: status => status >= 200 && status < 300,
     });
-    logger.info(`Forwarding request to ${parsedUrl.toString()}`);
-    const axiosParams = {
-      url: urlWithApiKey,
-      method: method,
-      data: body,
-      responseType: responseType,
-    };
-    console.log("Params: " + JSON.stringify(axiosParams));
-    const response = await axios(axiosParams);
 
-    res.status(response.status);
-    if (responseType === "stream") {
-      response.data.pipe(res);
-    } else {
-      res.send(response.data);
+    const expectsJson = parsedUrl.searchParams.get("retmode") === "json";
+    if (expectsJson) {
+      try {
+        return res.status(response.status).json(JSON.parse(String(response.data)));
+      } catch {
+        return res.status(502).json({error: "NCBI returned malformed JSON."});
+      }
     }
+    return res.status(response.status).type("text/plain").send(response.data);
   } catch (error) {
-    logger.error(`Error in forwarding request: ${error}`);
-    res.status(500).send({ error: error });
+    if (error instanceof NcbiQueueFullError) return res.status(503).json({error: error.message});
+    if (axios.isAxiosError(error)) {
+      const upstreamStatus = error.response?.status;
+      logger.warn({requestId: req.requestId, message: "NCBI request failed", upstreamStatus});
+      return res.status(upstreamStatus === 429 ? 429 : 502).json({
+        error: upstreamStatus === 429
+          ? "NCBI is rate limiting requests. Try again shortly."
+          : "NCBI is temporarily unavailable.",
+      });
+    }
+    logger.warn({requestId: req.requestId, message: "Rejected external request", error: String(error)});
+    return res.status(400).json({error: "Invalid external request"});
   }
 });
 

--- a/ncd-calculator/README.md
+++ b/ncd-calculator/README.md
@@ -2,6 +2,8 @@
 
 Browser-based normalized compression distance analysis for GenBank sequences, Universal Declaration of Human Rights translations, and local files. Compression, matrix construction, and layout optimization run in web workers so the interface remains responsive.
 
+GenBank/NCBI Nucleotide retrieval is fail-fast and version-pinned: ESummary metadata and FASTA content must agree on accession version and sequence length before a record can enter a comparison. Cached records carry a SHA-256 digest and typed provenance and are revalidated before reuse. See [`docs/GENBANK_SEQUENCE_PIPELINE.md`](docs/GENBANK_SEQUENCE_PIPELINE.md) for the scientific scope, limits, and reproducibility contract.
+
 ## Start the interface
 
 ```bash

--- a/ncd-calculator/docs/GENBANK_SEQUENCE_PIPELINE.md
+++ b/ncd-calculator/docs/GENBANK_SEQUENCE_PIPELINE.md
@@ -1,0 +1,41 @@
+# GenBank sequence pipeline
+
+Last updated: 2026-08-07
+
+## Scope
+
+CompLearn retrieves public nucleotide records through the NCBI Nucleotide (`nuccore`) E-utilities service. NCBI Nucleotide includes archival GenBank records and NCBI-derived records such as RefSeq. A record passing this pipeline is a faithful, versioned copy of the sequence NCBI served at retrieval time. That does not prove that the submitter's organism identification, assembly, annotation, or biological interpretation is correct. GenBank performs automated validation and manual review during submission, but archival records can still contain contamination, sequencing error, chimeras, misassemblies, incomplete coverage, or later revisions. NCBI describes its processing responsibilities in [NLM GenBank and SRA Data Processing](https://www.ncbi.nlm.nih.gov/sra/docs/sequence-data-processing/) and its sequence-quality checks in [Ribosomal RNA Sequence Processing](https://www.ncbi.nlm.nih.gov/genbank/sequencecheck/).
+
+NCD measures similarity between the bytes supplied to the compressor. A valid GenBank record is therefore necessary but not sufficient for a valid biological experiment. Researchers must choose comparable material. For phylogenetic or taxonomic work, records should normally represent the same locus or the same complete organelle/genome scope, use compatible orientation, have similar completeness, and exclude known problematic records. Mixing a complete genome, a short marker, and an unrelated chromosome produces a valid compression calculation but usually not a defensible biological comparison.
+
+## Retrieval and verification contract
+
+The `genbank-sequence-v2` pipeline applies these stages in order and stops at the first failure:
+
+1. Accept one to 64 unique NCBI UIDs or accession identifiers. Accession versions are retained rather than stripped.
+2. Retrieve ESummary metadata, followed by FASTA content, in bounded requests through the backend.
+3. Resolve every requested identifier through its NCBI UID and `accessionversion`. Response order is never used as identity.
+4. Parse every FASTA record independently. Headers, duplicate accessions, empty records, and characters outside the IUPAC nucleotide alphabet are rejected.
+5. Require the returned FASTA accession version to equal the ESummary accession version. Silent substitution of an older or newer sequence version is rejected.
+6. Require the parsed base count to equal ESummary `slen` exactly.
+7. Enforce resource limits of 20 million bases per record and 128 million bases per comparison before compression begins.
+8. Compute SHA-256 over the normalized uppercase nucleotide sequence and retain the digest with the NCBI UID, accession, accession version, title, organism, taxonomy ID, expected length, retrieval time, and permanent record URL.
+9. Admit the comparison only when every selected object resolves to non-empty, validated content. Partial batches never continue to NCD.
+
+Ambiguity symbols such as `N`, `R`, and `Y` are preserved because they are legitimate IUPAC nucleotide symbols and carry information about the submitted record. Whitespace and FASTA headers are excluded from compression. Letter case is normalized to uppercase so formatting differences do not create artificial distance.
+
+## Cache behavior
+
+The browser cache stores the sequence together with its complete provenance record. A cached entry is reused only when its pipeline version, requested identifier, expected length, IUPAC validation, and SHA-256 digest all pass. The storage schema version was raised to 52, which removes older sequence-only cache entries. This prevents unversioned, truncated, corrupted, or previously mis-associated content from entering a new analysis.
+
+The cache makes repeated interactive analyses efficient, but it is not a permanent scientific archive. A reproducible publication or experiment should record the accession version and digest from the typed provenance data. If long-term byte-for-byte recovery is required, export or archive the exact validated FASTA inputs with the analysis.
+
+## Scaling and NCBI policy
+
+All browser requests pass through a backend scheduler. The scheduler removes client-supplied API keys, adds the server-owned key plus the configured `tool` and `email`, and permits only HTTPS requests to the ESearch, ESummary, and EFetch endpoints for the supported NCBI databases. It limits the shared process to three requests per second without an API key or ten with one, allows at most four upstream requests concurrently, keeps a bounded queue, retries transient network, rate-limit, and 5xx failures with exponential delay, honors `Retry-After`, and caps response size and request duration. These values follow the [NCBI E-utilities usage guidelines](https://www.ncbi.nlm.nih.gov/books/NBK25497/).
+
+Interactive browser analysis remains intentionally bounded. A server-side batch workflow using Entrez History, durable object storage, job isolation, and exported manifests is the appropriate next architecture for hundreds or thousands of large genomes. Increasing the browser limit would consume more memory without making the experiment more reliable.
+
+## Recommended research procedure
+
+Define the biological comparison rule before searching. Record why each locus or genome scope is comparable, prefer explicit accession versions, inspect NCBI titles and source metadata, exclude suppressed or unsuitable records, and save the exact accession-version list and sequence hashes with the result. Repeat the analysis with a documented alternative compressor or carefully justified record set when conclusions depend on small distance differences. Treat the quartet tree as a topology optimized from the selected compression distances, not as automatic proof of evolutionary ancestry.

--- a/ncd-calculator/src/__test__/genbankSequencePipeline.test.ts
+++ b/ncd-calculator/src/__test__/genbankSequencePipeline.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, test} from "vitest";
+import {
+    assembleValidatedGenBankRecords,
+    GENBANK_SEQUENCE_PIPELINE_VERSION,
+    parseStrictNcbiFasta,
+    validateGenBankNucleotideSequence,
+    verifyCachedGenBankRecord,
+} from "../services/genbankSequencePipeline";
+
+const summary = (overrides: Record<string, unknown> = {}) => ({
+    result: {
+        uids: ["42"],
+        "42": {
+            uid: "42",
+            accessionversion: "NC_000001.2",
+            title: "Example mitochondrion, complete genome",
+            organism: "Example species",
+            taxid: 123,
+            slen: 15,
+            ...overrides,
+        },
+    },
+});
+
+describe("GenBank sequence pipeline", () => {
+    test("accepts the complete IUPAC nucleotide alphabet and preserves accession versions", async () => {
+        const records = await assembleValidatedGenBankRecords(
+            ["NC_000001.2"],
+            ">NC_000001.2 Example species\r\nACGTURYSWKMBDHV\r\n",
+            summary(),
+            "2026-08-07T00:00:00.000Z",
+        );
+
+        expect(records).toHaveLength(1);
+        expect(records[0].sequence).toBe("ACGTURYSWKMBDHV");
+        expect(records[0].provenance).toMatchObject({
+            pipelineVersion: GENBANK_SEQUENCE_PIPELINE_VERSION,
+            requestedId: "NC_000001.2",
+            accession: "NC_000001",
+            accessionVersion: "NC_000001.2",
+            uid: "42",
+            expectedLength: 15,
+        });
+        expect(records[0].provenance.sha256).toMatch(/^[a-f0-9]{64}$/u);
+    });
+
+    test("maps a numeric UID through ESummary instead of relying on FASTA order", async () => {
+        const [record] = await assembleValidatedGenBankRecords(
+            ["42"],
+            ">NC_000001.2 Example species\nACGTURYSWKMBDHV\n",
+            summary(),
+        );
+        expect(record.provenance.requestedId).toBe("42");
+        expect(record.provenance.accessionVersion).toBe("NC_000001.2");
+    });
+
+    test("fails fast when FASTA content and NCBI summary lengths disagree", async () => {
+        await expect(assembleValidatedGenBankRecords(
+            ["NC_000001.2"],
+            ">NC_000001.2 Example species\nACGT\n",
+            summary(),
+        )).rejects.toThrow("length verification failed");
+    });
+
+    test("rejects invalid characters, duplicate records, and version substitution", async () => {
+        expect(() => validateGenBankNucleotideSequence("ACGTZ")).toThrow("IUPAC");
+        expect(() => parseStrictNcbiFasta(
+            ">NC_000001.2 first\nACGT\n>NC_000001.2 duplicate\nACGT\n",
+        )).toThrow("same accession");
+        await expect(assembleValidatedGenBankRecords(
+            ["NC_000001.2"],
+            ">NC_000001.1 stale version\nACGTURYSWKMBDHV\n",
+            summary(),
+        )).rejects.toThrow("different sequence version");
+    });
+
+    test("accepts only intact, pipeline-versioned cached records", async () => {
+        const [record] = await assembleValidatedGenBankRecords(
+            ["NC_000001.2"],
+            ">NC_000001.2 Example species\nACGTURYSWKMBDHV\n",
+            summary(),
+        );
+        await expect(verifyCachedGenBankRecord(record, "NC_000001.2")).resolves.toEqual(record);
+        await expect(verifyCachedGenBankRecord({...record, sequence: `${record.sequence}A`}, "NC_000001.2"))
+            .resolves.toBeNull();
+        await expect(verifyCachedGenBankRecord(record, "NC_999999.1")).resolves.toBeNull();
+    });
+});

--- a/ncd-calculator/src/cache/LocalStorageKeyManager.ts
+++ b/ncd-calculator/src/cache/LocalStorageKeyManager.ts
@@ -1,5 +1,5 @@
 export const STORAGE_VERSION_NAME = "complearn_storage_version";
-export const STORAGE_VERSION = 51;
+export const STORAGE_VERSION = 52;
 export const LOG_PREFIX = "[Storage Manager]";
 
 type StorageKeyFunction = () => string;

--- a/ncd-calculator/src/components/FastaSearch.tsx
+++ b/ncd-calculator/src/components/FastaSearch.tsx
@@ -57,6 +57,9 @@ export const FastaSearch: React.FC<FastaSearchProps> = ({
               displayMode="common"
           />
         </div>
+        <p className="source-browser__provenance">
+          Records are retrieved from NCBI Nucleotide. NCBI does not endorse this application.
+        </p>
       </div>
   );
 };

--- a/ncd-calculator/src/components/ListEditor.tsx
+++ b/ncd-calculator/src/components/ListEditor.tsx
@@ -2,7 +2,7 @@
  * @module components/ListEditor
  *
  * Input management component for the NCD calculator. Provides three input modes:
- * - **FASTA Search** — Search NCBI GenBank for DNA/protein sequences by accession or name
+ * - **FASTA Search** — Search NCBI Nucleotide for versioned nucleotide sequences
  * - **File Upload** — Drag-and-drop or browse for local files (any format)
  * - **Languages** — Select UDHR (Universal Declaration of Human Rights) translations
  *
@@ -34,19 +34,14 @@ import {saveAs} from "file-saver";
 import type {QTreeResponse} from "@/types/qsearch";
 import {getWorkbenchExampleItems} from "./workbenchExamples";
 import type {SelectedItem} from "./workbenchTypes";
+import {
+	type GenBankSequenceRecord,
+	validateGenBankNucleotideSequence,
+	verifyCachedGenBankRecord,
+} from "../services/genbankSequencePipeline";
 export type {SelectedItem} from "./workbenchTypes";
 export interface SearchMode {
 	searchMode: string;
-}
-
-export interface FastaSequenceResponse {
-	accessions: string[];
-	contents: string[];
-}
-
-export interface ProcessedFastaItem {
-	sequence: string;
-	accession: string;
 }
 
 export interface NcdInput {
@@ -215,8 +210,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 		[]
 	);
 	
-	const apiKey = import.meta.env.VITE_NCBI_API_KEY ?? "";
-	
 	const [fastaSuggestionStartIndex, setFastaSuggestionStartIndex] =
 		React.useState<Record<string, number>>({});
 	
@@ -228,8 +221,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	
 	// Computed values
 	const isSearchDisabled =
-		selectedItems.length < MIN_ITEMS ||
-		(searchMode.searchMode === "fasta" && !apiKey && selectedItems.length < MIN_ITEMS);
+		selectedItems.length < MIN_ITEMS;
 	const isClearDisabled = selectedItems.length === 0;
 	
 	// Rehydrate canonical names for selections restored from older localStorage
@@ -302,6 +294,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 				});
 			} else {
 				const computedNcdInput = await computeNcdInput(selectedItems);
+				await assertCompleteComparisonSet(selectedItems, computedNcdInput);
 				// update the items with their computed content
 				const ncdSelectedItems = updateLabelsWithComputedContent(computedNcdInput, selectedItems);
 				
@@ -324,25 +317,39 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	
 	const computeNcdInput = async (selectedItems: SelectedItem[]): Promise<SelectedItem[]> => {
 		const langItems = selectedItems.filter((item) => item.type === LANGUAGE);
-		const fastaItems = selectedItems.filter(
-			(item) => item.type === FASTA || item.type === FILE_UPLOAD
-		);
+		const fastaItems = selectedItems.filter((item) => item.type === FASTA);
+		const fileItems = selectedItems.filter((item) => item.type === FILE_UPLOAD);
 		
 		const orderMap = getOrderMap(selectedItems);
 		const langNcdInput = await computeLanguageNcdInput(langItems);
-		const fastaNcdInput = getCachedFastaContent(fastaItems);
+		const fastaNcdInput = await getCachedFastaContent(fastaItems);
+		const resolvedFastaIds = new Set(fastaNcdInput.map(item => item.id));
 		
 		const needComputeFastaList = await computeFastaNcdInput(
-			fastaItems.filter((item) => !item.content || item.content.trim() === ""),
-			apiKey
+			fastaItems.filter(item => !resolvedFastaIds.has(item.id)),
 		);
 		
-		const mergedFastaInput = [
+		const mergedObjectInput = [
+			...fileItems,
 			...fastaNcdInput,
-			...(needComputeFastaList || []),
+			...needComputeFastaList,
 		];
 		
-		return mergeAndPreserveInitialOrder(langNcdInput, mergedFastaInput, orderMap);
+		return mergeAndPreserveInitialOrder(langNcdInput, mergedObjectInput, orderMap);
+	};
+
+	const assertCompleteComparisonSet = async (
+		requestedItems: readonly SelectedItem[],
+		resolvedItems: readonly SelectedItem[],
+	): Promise<void> => {
+		const resolvedById = new Map(resolvedItems.map(item => [item.id, item]));
+		const missing = requestedItems.filter(item => !resolvedById.get(item.id)?.content?.trim());
+		if (missing.length > 0) {
+			throw new Error(`Unable to retrieve valid content for: ${missing.map(item => item.label || item.id).join(", ")}.`);
+		}
+		for (const item of resolvedItems) {
+			if (item.type === FASTA) validateGenBankNucleotideSequence(item.content ?? "");
+		}
 	};
 	
 	
@@ -365,22 +372,20 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	}
 	
 	
-	const getCachedFastaContent = (items: SelectedItem[]): SelectedItem[] => {
-		const res = items.filter(
-			(item) => item.content && item.content.trim() !== ""
-		);
-		
-		const withoutContent = items.filter(
-			(item) => !item.content || item.content.trim() === ""
-		);
-		
-		for (let i = 0; i < withoutContent.length; i++) {
-			const item = withoutContent[i];
-			const sequence = localStorageManager.get<string>(LocalStorageKeys.ACCESSION_SEQUENCE, item.id) || "";
-			if (sequence && sequence.trim() !== "") {
-				item.content = sequence;
-				res.push(item);
+	const getCachedFastaContent = async (items: SelectedItem[]): Promise<SelectedItem[]> => {
+		const res: SelectedItem[] = [];
+		for (const item of items) {
+			const inlineRecord: GenBankSequenceRecord | null = item.content && item.genBankProvenance
+				? {sequence: item.content, provenance: item.genBankProvenance}
+				: null;
+			const cachedRecord = inlineRecord
+				?? localStorageManager.get<GenBankSequenceRecord>(LocalStorageKeys.ACCESSION_SEQUENCE, item.id);
+			const verified = await verifyCachedGenBankRecord(cachedRecord, item.id);
+			if (!verified) {
+				localStorageManager.remove(LocalStorageKeys.ACCESSION_SEQUENCE, item.id);
+				continue;
 			}
+			res.push({...item, content: verified.sequence, genBankProvenance: verified.provenance});
 		}
 		
 		return res;
@@ -453,26 +458,20 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	
 	const computeFastaNcdInput = async (
 		fastaItems: SelectedItem[],
-		_apiKey: string
 	): Promise<SelectedItem[]> => {
 		if (!isValidInput(fastaItems)) return [];
-		try {
-			const searchResults = await fetchFastaSequenceAndProcess(fastaItems);
-			if (searchResults.length === 0) return [];
-			cacheAccessionSequence(searchResults);
-			return searchResults;
-		} catch (error) {
-			console.error("Error in computeFastaNcdInput:", error);
-			return [];
-		}
+		const searchResults = await fetchFastaSequenceAndProcess(fastaItems);
+		cacheAccessionSequence(searchResults);
+		return searchResults;
 	};
 	
 	const cacheAccessionSequence = (suggestions: SelectedItem[]): void => {
 		suggestions.forEach((suggestion) => {
-			const id = suggestion.id;
-			const content = suggestion.content;
-			if (content) {
-				localStorageManager.set(LocalStorageKeys.ACCESSION_SEQUENCE, id, content);
+			if (suggestion.content && suggestion.genBankProvenance) {
+				localStorageManager.set<GenBankSequenceRecord>(LocalStorageKeys.ACCESSION_SEQUENCE, suggestion.id, {
+					sequence: suggestion.content,
+					provenance: suggestion.genBankProvenance,
+				});
 			}
 		});
 	};
@@ -497,21 +496,18 @@ const ListEditor: React.FC<ListEditorProps> = ({
 		});
 		
 		const response = await getFastaSequences(idsToFetch);
-		const arr = toArr(response);
-		arr.forEach((item) => {
-			const fastItem = map.get(item.accession);
-			if (fastItem) {
-				fastItem.content = item.sequence;
-			}
+		response.forEach((record) => {
+			const fastItem = map.get(record.provenance.requestedId);
+			if (!fastItem) throw new Error(`Unexpected GenBank response for ${record.provenance.requestedId}.`);
+			fastItem.content = record.sequence;
+			fastItem.genBankProvenance = record.provenance;
 		});
-		return Array.from(map.values());
-	};
-	
-	const toArr = (response: FastaSequenceResponse): ProcessedFastaItem[] => {
-		return response.accessions.map((accession, i) => ({
-			sequence: response.contents[i],
-			accession,
-		}));
+		const resolved = Array.from(map.values());
+		const missing = resolved.filter(item => !item.content || !item.genBankProvenance);
+		if (missing.length > 0) {
+			throw new Error(`NCBI did not resolve: ${missing.map(item => item.id).join(", ")}.`);
+		}
+		return resolved;
 	};
 	
 	const addItem = (item: SelectedItem): void => {

--- a/ncd-calculator/src/components/Workbench.css
+++ b/ncd-calculator/src/components/Workbench.css
@@ -159,6 +159,15 @@
     scrollbar-gutter: stable;
 }
 
+.source-browser__provenance {
+    margin: 0;
+    padding: 9px 26px;
+    color: var(--ink-muted);
+    border-top: 1px solid var(--line);
+    font-size: 0.72rem;
+    line-height: 1.45;
+}
+
 .source-option-list {
     margin: 0;
     padding: 0;

--- a/ncd-calculator/src/components/workbenchTypes.ts
+++ b/ncd-calculator/src/components/workbenchTypes.ts
@@ -1,4 +1,5 @@
 import {FASTA, FILE_UPLOAD, LANGUAGE} from "../constants/modalConstants";
+import type {GenBankSequenceProvenance} from "../services/genbankSequencePipeline";
 
 export interface SelectedItem {
     id: string;
@@ -6,4 +7,5 @@ export interface SelectedItem {
     content?: string;
     type: typeof FASTA | typeof LANGUAGE | typeof FILE_UPLOAD;
     cacheKey?: string;
+    genBankProvenance?: GenBankSequenceProvenance;
 }

--- a/ncd-calculator/src/functions/getPublicGenbank.ts
+++ b/ncd-calculator/src/functions/getPublicGenbank.ts
@@ -1,52 +1,53 @@
 import {sendRequestToProxy} from "./fetchProxy";
-import {parseFastaAndClean} from "./fasta";
+import {
+    assembleValidatedGenBankRecords,
+    MAX_GENBANK_RECORDS_PER_REQUEST,
+    type GenBankSequenceRecord,
+} from "../services/genbankSequencePipeline";
 
-const parseGenbankList = (text: string): {
-    labels: string[],
-    scientificNames: string[],
-    accessions: string[],
-    commonNames: string[],
-    contents: string[]
-} => {
-    if (!text) {
-        return {
-            labels: [],
-            scientificNames: [],
-            accessions: [],
-            commonNames: [],
-            contents: []
-        };
+const EUTILS_BASE_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils";
+
+const createEutilsUri = (
+    endpoint: "efetch.fcgi" | "esummary.fcgi",
+    params: Record<string, string>,
+): string => {
+    const url = new URL(`${EUTILS_BASE_URL}/${endpoint}`);
+    url.search = new URLSearchParams({
+        db: "nuccore",
+        tool: "complearn-ncd",
+        ...params,
+    }).toString();
+    return url.toString();
+};
+
+/**
+ * Retrieve a bounded batch of versioned nucleotide records and verify every
+ * FASTA payload against its NCBI ESummary accession and sequence length.
+ */
+export const getFastaSequences = async (
+    ids: readonly string[],
+): Promise<readonly GenBankSequenceRecord[]> => {
+    if (ids.length > MAX_GENBANK_RECORDS_PER_REQUEST) {
+        throw new Error(`Select no more than ${MAX_GENBANK_RECORDS_PER_REQUEST} GenBank records per comparison.`);
     }
-    const parsed = parseFastaAndClean(text);
-    const scientificNames = parsed.map(item => item.scientificName);
-    const commonNames = parsed.map(item => item.commonName);
-    const accessions = parsed.map(item => item.accession);
-    const contents = parsed.map(item => item.sequence);
-    return {
-        labels: commonNames,
-        scientificNames: scientificNames,
-        accessions: accessions,
-        commonNames: commonNames,
-        contents: contents
-    };
-};
-
-
-const getGenbankListUri = (ids: string[]): string => {
-    const IDS = ids.join(",");
-    return `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=${IDS}&rettype=fasta&retmode=text`;
-};
-
-export const getFastaSequences = async (ids: string[]): Promise<{
-    labels: string[],
-    scientificNames: string[],
-    accessions: string[],
-    commonNames: string[],
-    contents: string[]
-}> => {
-    const uri = getGenbankListUri(ids);
-    const textResponse = await sendRequestToProxy({
-        externalUrl: uri
+    const joinedIds = ids.join(",");
+    const summaryUri = createEutilsUri("esummary.fcgi", {
+        id: joinedIds,
+        retmode: "json",
+        version: "2.0",
     });
-    return parseGenbankList(textResponse);
+    const fastaUri = createEutilsUri("efetch.fcgi", {
+        id: joinedIds,
+        rettype: "fasta",
+        retmode: "text",
+    });
+
+    // Keep the requests sequential. This respects NCBI's shared rate budget and
+    // lets us fail on malformed metadata before transferring sequence payloads.
+    const summaryResponse = await sendRequestToProxy({externalUrl: summaryUri});
+    const fastaResponse = await sendRequestToProxy({externalUrl: fastaUri});
+    if (typeof fastaResponse !== "string") {
+        throw new Error("NCBI returned an unexpected FASTA response type.");
+    }
+    return assembleValidatedGenBankRecords(ids, fastaResponse, summaryResponse);
 };

--- a/ncd-calculator/src/services/genbankSequencePipeline.ts
+++ b/ncd-calculator/src/services/genbankSequencePipeline.ts
@@ -1,0 +1,244 @@
+export const GENBANK_SEQUENCE_PIPELINE_VERSION = "genbank-sequence-v2";
+export const MAX_GENBANK_RECORDS_PER_REQUEST = 64;
+export const MAX_GENBANK_SEQUENCE_LENGTH = 20_000_000;
+export const MAX_GENBANK_TOTAL_BASES = 128_000_000;
+
+const ACCESSION_PATTERN = /^(?:[A-Z]{1,6}_?)\d+(?:\.\d+)?$/i;
+const NUCLEOTIDE_PATTERN = /^[ACGTURYSWKMBDHVN]+$/i;
+
+export interface GenBankSequenceProvenance {
+    readonly pipelineVersion: typeof GENBANK_SEQUENCE_PIPELINE_VERSION;
+    readonly database: "nuccore";
+    readonly requestedId: string;
+    readonly uid: string;
+    readonly accession: string;
+    readonly accessionVersion: string;
+    readonly title: string;
+    readonly organism: string;
+    readonly taxId: string;
+    readonly expectedLength: number;
+    readonly retrievedAt: string;
+    readonly recordUrl: string;
+    readonly sha256: string;
+}
+
+export interface GenBankSequenceRecord {
+    readonly sequence: string;
+    readonly provenance: GenBankSequenceProvenance;
+}
+
+interface ParsedFastaRecord {
+    readonly accessionVersion: string;
+    readonly sequence: string;
+}
+
+interface NcbiSummaryRecord {
+    readonly uid?: unknown;
+    readonly accessionversion?: unknown;
+    readonly title?: unknown;
+    readonly organism?: unknown;
+    readonly taxid?: unknown;
+    readonly slen?: unknown;
+}
+
+interface NcbiSummaryResponse {
+    readonly result?: Record<string, NcbiSummaryRecord | unknown>;
+}
+
+const normalizeIdentifier = (value: string): string => value.trim().toUpperCase();
+const accessionWithoutVersion = (value: string): string => normalizeIdentifier(value).split(".")[0];
+
+const requireRequestedIds = (requestedIds: readonly string[]): readonly string[] => {
+    if (requestedIds.length === 0) throw new Error("No GenBank records were requested.");
+    if (requestedIds.length > MAX_GENBANK_RECORDS_PER_REQUEST) {
+        throw new Error(`A comparison can retrieve at most ${MAX_GENBANK_RECORDS_PER_REQUEST} GenBank records at once.`);
+    }
+    const normalized = requestedIds.map(identifier => identifier.trim());
+    if (normalized.some(identifier => !identifier || (!/^\d+$/.test(identifier) && !ACCESSION_PATTERN.test(identifier)))) {
+        throw new Error("The GenBank request contains an invalid accession or UID.");
+    }
+    if (new Set(normalized.map(normalizeIdentifier)).size !== normalized.length) {
+        throw new Error("The GenBank request contains duplicate records.");
+    }
+    return normalized;
+};
+
+const getHeaderAccession = (header: string): string => {
+    const firstToken = header.slice(1).trim().split(/\s+/u)[0] ?? "";
+    const candidates = firstToken.split("|").filter(Boolean);
+    const accession = candidates.find(candidate => ACCESSION_PATTERN.test(candidate));
+    if (!accession) throw new Error(`NCBI returned an invalid FASTA header: ${header.slice(0, 120)}`);
+    return normalizeIdentifier(accession);
+};
+
+export const validateGenBankNucleotideSequence = (sequence: string): string => {
+    const normalized = sequence.replace(/\s+/gu, "").toUpperCase();
+    if (!normalized) throw new Error("NCBI returned an empty nucleotide sequence.");
+    if (!NUCLEOTIDE_PATTERN.test(normalized)) {
+        throw new Error("NCBI returned characters outside the IUPAC nucleotide alphabet.");
+    }
+    if (normalized.length > MAX_GENBANK_SEQUENCE_LENGTH) {
+        throw new Error(
+            `A GenBank sequence exceeds the browser-safe limit of ${MAX_GENBANK_SEQUENCE_LENGTH.toLocaleString()} bases.`,
+        );
+    }
+    return normalized;
+};
+
+export const parseStrictNcbiFasta = (text: string): readonly ParsedFastaRecord[] => {
+    const normalizedText = text.replace(/^\uFEFF/u, "").replace(/\r\n?/gu, "\n").trim();
+    if (!normalizedText) throw new Error("NCBI returned an empty FASTA response.");
+
+    const records: ParsedFastaRecord[] = [];
+    let accessionVersion: string | null = null;
+    let sequenceLines: string[] = [];
+    const finishRecord = (): void => {
+        if (!accessionVersion) return;
+        records.push({
+            accessionVersion,
+            sequence: validateGenBankNucleotideSequence(sequenceLines.join("")),
+        });
+    };
+
+    for (const line of normalizedText.split("\n")) {
+        if (line.startsWith(">")) {
+            finishRecord();
+            accessionVersion = getHeaderAccession(line);
+            sequenceLines = [];
+        } else {
+            if (!accessionVersion) throw new Error("NCBI returned sequence data before the first FASTA header.");
+            sequenceLines.push(line);
+        }
+    }
+    finishRecord();
+
+    const identifiers = records.map(record => record.accessionVersion);
+    if (new Set(identifiers).size !== identifiers.length) {
+        throw new Error("NCBI returned the same accession more than once.");
+    }
+    return records;
+};
+
+const parsePositiveInteger = (value: unknown, field: string, accessionVersion: string): number => {
+    const parsed = typeof value === "number" ? value : Number.parseInt(String(value), 10);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+        throw new Error(`NCBI summary for ${accessionVersion} has an invalid ${field}.`);
+    }
+    return parsed;
+};
+
+const sha256 = async (value: string): Promise<string> => {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+    return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("");
+};
+
+export const assembleValidatedGenBankRecords = async (
+    requestedIds: readonly string[],
+    fastaText: string,
+    summaryResponse: NcbiSummaryResponse,
+    retrievedAt = new Date().toISOString(),
+): Promise<readonly GenBankSequenceRecord[]> => {
+    const requested = requireRequestedIds(requestedIds);
+    const fastaRecords = parseStrictNcbiFasta(fastaText);
+    const rawSummaries = summaryResponse.result;
+    if (!rawSummaries || typeof rawSummaries !== "object") {
+        throw new Error("NCBI returned a malformed sequence summary.");
+    }
+
+    const summaries = Object.entries(rawSummaries)
+        .filter(([key, value]) => key !== "uids" && value && typeof value === "object")
+        .map(([, value]) => value as NcbiSummaryRecord)
+        .map(summary => {
+            const uid = String(summary.uid ?? "").trim();
+            const accessionVersion = normalizeIdentifier(String(summary.accessionversion ?? ""));
+            if (!uid || !ACCESSION_PATTERN.test(accessionVersion)) {
+                throw new Error("NCBI returned a sequence summary without a stable UID and accession version.");
+            }
+            return {summary, uid, accessionVersion};
+        });
+
+    const byUid = new Map(summaries.map(summary => [summary.uid, summary]));
+    const byAccession = new Map(summaries.map(summary => [summary.accessionVersion, summary]));
+    const fastaByAccession = new Map(fastaRecords.map(record => [record.accessionVersion, record]));
+    const results: GenBankSequenceRecord[] = [];
+    let totalBases = 0;
+
+    for (const requestedId of requested) {
+        const normalizedRequest = normalizeIdentifier(requestedId);
+        const summaryEntry = byUid.get(normalizedRequest)
+            ?? byAccession.get(normalizedRequest)
+            ?? summaries.find(candidate => accessionWithoutVersion(candidate.accessionVersion) === accessionWithoutVersion(normalizedRequest));
+        if (!summaryEntry) throw new Error(`NCBI did not return metadata for ${requestedId}.`);
+
+        const fasta = fastaByAccession.get(summaryEntry.accessionVersion)
+            ?? fastaRecords.find(record => (
+                accessionWithoutVersion(record.accessionVersion) === accessionWithoutVersion(summaryEntry.accessionVersion)
+            ));
+        if (!fasta) throw new Error(`NCBI did not return sequence data for ${summaryEntry.accessionVersion}.`);
+        if (fasta.accessionVersion !== summaryEntry.accessionVersion) {
+            throw new Error(`NCBI returned a different sequence version for ${summaryEntry.accessionVersion}.`);
+        }
+
+        const expectedLength = parsePositiveInteger(
+            summaryEntry.summary.slen,
+            "sequence length",
+            summaryEntry.accessionVersion,
+        );
+        if (fasta.sequence.length !== expectedLength) {
+            throw new Error(
+                `NCBI length verification failed for ${summaryEntry.accessionVersion}: expected ${expectedLength}, received ${fasta.sequence.length}.`,
+            );
+        }
+        totalBases += fasta.sequence.length;
+        if (totalBases > MAX_GENBANK_TOTAL_BASES) {
+            throw new Error(`The selected GenBank records exceed the ${MAX_GENBANK_TOTAL_BASES.toLocaleString()}-base comparison limit.`);
+        }
+
+        results.push({
+            sequence: fasta.sequence,
+            provenance: {
+                pipelineVersion: GENBANK_SEQUENCE_PIPELINE_VERSION,
+                database: "nuccore",
+                requestedId,
+                uid: summaryEntry.uid,
+                accession: accessionWithoutVersion(summaryEntry.accessionVersion),
+                accessionVersion: summaryEntry.accessionVersion,
+                title: String(summaryEntry.summary.title ?? "").trim(),
+                organism: String(summaryEntry.summary.organism ?? "").trim(),
+                taxId: String(summaryEntry.summary.taxid ?? "").trim(),
+                expectedLength,
+                retrievedAt,
+                recordUrl: `https://www.ncbi.nlm.nih.gov/nuccore/${encodeURIComponent(summaryEntry.accessionVersion)}`,
+                sha256: await sha256(fasta.sequence),
+            },
+        });
+    }
+
+    if (new Set(results.map(record => record.provenance.accessionVersion)).size !== results.length) {
+        throw new Error("Multiple requested identifiers resolved to the same GenBank sequence version.");
+    }
+    return results;
+};
+
+export const verifyCachedGenBankRecord = async (
+    value: unknown,
+    requestedId: string,
+): Promise<GenBankSequenceRecord | null> => {
+    if (!value || typeof value !== "object") return null;
+    const candidate = value as Partial<GenBankSequenceRecord>;
+    const provenance = candidate.provenance as Partial<GenBankSequenceProvenance> | undefined;
+    if (
+        provenance?.pipelineVersion !== GENBANK_SEQUENCE_PIPELINE_VERSION
+        || provenance.requestedId !== requestedId
+        || typeof candidate.sequence !== "string"
+        || typeof provenance.sha256 !== "string"
+    ) return null;
+
+    try {
+        const sequence = validateGenBankNucleotideSequence(candidate.sequence);
+        if (sequence.length !== provenance.expectedLength || await sha256(sequence) !== provenance.sha256) return null;
+        return {sequence, provenance: provenance as GenBankSequenceProvenance};
+    } catch {
+        return null;
+    }
+};

--- a/ncd-calculator/src/vite-env.d.ts
+++ b/ncd-calculator/src/vite-env.d.ts
@@ -4,7 +4,6 @@ interface ImportMetaEnv {
     readonly VITE_BACKEND_BASE_URL?: string;
     readonly VITE_BASE_URL?: string;
     readonly VITE_AUTH_ENABLED?: string;
-    readonly VITE_NCBI_API_KEY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Introduce a fail-fast, version-pinned GenBank/NCBI Nucleotide retrieval pipeline for scientifically traceable NCD inputs.

This PR is limited to GenBank retrieval, validation, caching, backend scheduling, tests, and documentation. It does not include the astronomy corpus or compression-worker startup changes.

## Problems addressed

The previous path accepted FASTA response order as identity, stored sequence-only cache values, swallowed partial retrieval failures, and exposed an NCBI API-key setting to frontend code. The backend proxy also accepted more request configuration than the application needed and rotated several nominal API keys without a process-wide NCBI rate budget.

Those behaviors could silently associate the wrong sequence with a selected item, reuse stale or corrupted content, proceed with incomplete comparison sets, leak credentials into a browser bundle, or exceed the service policy as traffic scaled.

## Retrieval and integrity contract

- Accept at most 64 unique NCBI UIDs or accession identifiers per request.
- Retrieve ESummary metadata before FASTA content through the backend-only E-utilities client.
- Resolve identity through UID and `accessionversion`; response order is never used.
- Require exact FASTA accession-version and ESummary sequence-length agreement.
- Validate the complete IUPAC nucleotide alphabet and reject empty, duplicated, malformed, or substituted records.
- Bound each record to 20 million bases and a comparison to 128 million total bases.
- Normalize sequence text to uppercase bases without FASTA headers or whitespace.
- Record SHA-256, UID, accession version, organism, taxonomy ID, title, length, retrieval timestamp, and NCBI record URL.
- Stop the comparison unless every selected object has complete validated content.

## Backend reliability and security

- Keep the optional API key and maintainer email on the backend; client-supplied keys are removed.
- Restrict proxy targets to HTTPS NCBI E-utilities paths and supported databases.
- Use one bounded process-wide scheduler at three requests per second without a key or ten with a key.
- Apply the same shared rate budget to retries as first attempts.
- Allow at most four concurrent requests and 256 pending requests.
- Retry transient network, 429, and selected 5xx failures with bounded exponential delay and `Retry-After` support.
- Bound upstream duration, response size, and request body size.
- Return controlled errors without exposing upstream internals.

## Cache behavior

Validated records are cached with typed provenance rather than as sequence-only strings. Every cache reuse checks the pipeline version, requested identifier, IUPAC content, expected length, and SHA-256 digest. Storage schema version 52 removes incompatible legacy cache entries.

## Scientific scope

Passing these checks means the bytes faithfully represent the versioned sequence NCBI served at retrieval time. It does not establish that the submitter identification, assembly, annotation, locus choice, or biological comparison design is correct. The included guide explains comparable-record selection and the limits of interpreting an NCD quartet tree as phylogeny.

## Validation

Validated from the independent `agent/genbank-verified-pipeline` branch at commit `72cc8d9`:

- Backend NCBI tests: 6 passed.
- Backend TypeScript build: passed.
- Frontend GenBank and workbench tests: 13 passed.
- Frontend production build: passed, including all 501 UDHR records and bundle verification.
- Staged-diff whitespace validation: passed.

The build retains existing non-blocking Vite deprecation, browser-externalization, and large-chunk warnings.
