### PR TITLE
feat(export): add reproducible clustering experiment JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Based on the paper [Clustering by Compression](https://homepages.cwi.nl/~paulv/p
 
 The calculator includes a locally bundled, integrity-checked GRS 1915+105 RXTE time-series example based on the astronomy experiment in Section VIII-F. It uses a reproducible CC BY 4.0 public analogue because the paper's exact 16 privately supplied intervals are not publicly identified. The data contract and scientific limitations are in [`ncd-calculator/docs/ASTRONOMY_EXAMPLE.md`](ncd-calculator/docs/ASTRONOMY_EXAMPLE.md).
 
+Completed clustering experiments can be downloaded as versioned JSON containing the exact inputs, compression records, NCD matrices, quartet topology, search metadata, and integrity hashes. See [`ncd-calculator/docs/CLUSTERING_EXPERIMENT_EXPORT.md`](ncd-calculator/docs/CLUSTERING_EXPERIMENT_EXPORT.md).
+
 ### Development environment
 ##### Configure NCBI E-utilities
 1. Go to: https://account.ncbi.nlm.nih.gov/settings/ > *Account Settings*

--- a/ncd-calculator/README.md
+++ b/ncd-calculator/README.md
@@ -25,6 +25,8 @@ The sequence example contains two intentionally related pairs. It exercises the 
 
 The quartet-tree result opens in a planar 2D presentation so topology and labels can be read without manipulating a camera. The view automatically fits after layout and when the viewport changes, and provides explicit zoom, fit, and reset controls. **Interactive 3D** remains available for spatial exploration; its camera also fits the complete tree on entry and resize, while node selection reports whether the selected point is a leaf or an internal node.
 
+After QSearch finishes, **Download JSON** exports the complete current experiment: exact UTF-8 inputs and source provenance, content hashes, all single and ordered-pair compressed sizes, directed and reflected-minimum matrices, the selected unrooted tree, edge stability, search seeds and score summary, timing, and integrity metadata. Imported matrices are marked explicitly and do not claim unavailable raw objects or compressor records. The versioned format and privacy implications are documented in [`docs/CLUSTERING_EXPERIMENT_EXPORT.md`](docs/CLUSTERING_EXPERIMENT_EXPORT.md), with its JSON Schema in [`public/schemas/clustering-experiment-v1.schema.json`](public/schemas/clustering-experiment-v1.schema.json).
+
 Pair compression is explicitly order-dependent. The worker first constructs the complete directed matrix with separate `C(x || y)` and `C(y || x)` cells, then derives the symmetric QSearch/K-grid input by taking the minimum of each pair of reflected matrix cells. Both matrices are retained in the typed result. Directed compression results are stored in a SHA-256 content-addressed, versioned cache; incompatible legacy caches are removed automatically. QSearch uses a deterministic multi-start seed schedule and records selected-topology frequency and per-edge split stability for reproducibility. These diagnostics are kept out of the primary interface and retained in the typed result, explicit DOT exports, and technical documentation. The complete numerical contract is in [`docs/NCD_QSEARCH_REPRODUCIBILITY.md`](docs/NCD_QSEARCH_REPRODUCIBILITY.md).
 
 ## Verification
@@ -34,6 +36,7 @@ npm run build
 npm run graphviz:verify-dev
 npm run astronomy:verify
 npm run workers:verify-dev
+npm run export-schema:verify
 npm run lint
 npm run test
 npm run typecheck
@@ -50,7 +53,7 @@ npm run dev -- --force
 
 The planar-tree interface reports initialization failures and offers **Retry renderer**. The shared loader deduplicates concurrent initialization and clears failed attempts before retrying. Compression workers use Vite's native `new Worker(new URL(...))` transform rather than dynamically importing `?worker` wrapper modules; `workers:verify-dev` transforms and serves both entries in middleware mode so development-only worker regressions fail before a build. The selected compressor starts lazily when a calculation begins—there is no competing ZSTD prewarm—and has a 30-second cold-start window. Native worker load and message-decoding failures are reported immediately and failed workers are terminated.
 
-Focused interface coverage is in `src/__test__/landingPage.test.tsx` and `src/__test__/workbench.test.tsx`.
+Focused interface and export coverage is in `src/__test__/landingPage.test.tsx`, `src/__test__/workbench.test.tsx`, and `src/__test__/clusteringExperimentExport.test.ts`.
 
 ### Reproducible UDHR inputs
 

--- a/ncd-calculator/docs/CLUSTERING_EXPERIMENT_EXPORT.md
+++ b/ncd-calculator/docs/CLUSTERING_EXPERIMENT_EXPORT.md
@@ -1,0 +1,41 @@
+# Clustering experiment JSON export
+
+Updated 2026-08-08 (Asia/Ho_Chi_Minh).
+
+## Purpose
+
+The result page provides **Download JSON** after the quartet search completes. The download is a scientific record of the current clustering experiment, not a screenshot or a visualization preset. It preserves the inputs and the numerical path from compressed lengths to the selected unrooted tree so another program can audit the result without reading browser state.
+
+The export format is `complearn-clustering-experiment`, schema version 1. Its machine-readable JSON Schema is stored at [`public/schemas/clustering-experiment-v1.schema.json`](../public/schemas/clustering-experiment-v1.schema.json). The file is serialized as compact UTF-8 JSON to avoid adding unnecessary memory and download overhead for large inputs.
+
+## Included data
+
+For object-based experiments, every input entry contains its stable identifier, display label, source type, exact UTF-8 text, byte length, SHA-256 digest, and content-addressed cache key. GenBank entries include the verified accession version, UID, organism, taxon, retrieval time, record URL, expected length, and sequence digest. UDHR entries include the complete immutable corpus and record provenance. Astronomy entries retain their immutable RXTE asset, source coordinates, class, cadence, canonicalization contract, and digest provenance. Local files retain their filename, and bundled sequence examples retain their example identifier. Because the exact input text is required to reproduce compression, local or otherwise sensitive file contents are included deliberately; users should inspect the source set before sharing an export.
+
+The distance section contains the complete ordered NCD matrix, the reflected-minimum matrix supplied to QSearch and K-grid, the compressor revision and pipeline contract, and all compressed sizes used in the calculation. The record set is complete even when some values came from the browser cache: cache hits and worker results are merged and checked before export. Each ordered `C(x,y)` remains separate from `C(y,x)`. Before a file is created, the exporter recalculates every directed NCD from `C(x)`, `C(y)`, and `C(x,y)`, reapplies the reflected-cell minimum, and refuses inconsistent state.
+
+The quartet-tree section identifies the tree as unrooted and stores its nodes, reciprocal edges, stable leaf identifiers, display labels, internal-edge support, most-balanced display split, QSearch pipeline version, seed summary, score range, selected-topology frequency, and support interpretation. Repeated-search edge percentages remain optimization stability, not bootstrap confidence. Internal planar or 3D coordinates are not included because they are presentation state and do not change the inferred topology. K-grid layout state is also excluded because this download is the quartet-tree experiment record; the common input matrices are included.
+
+An imported distance-matrix experiment cannot provide raw objects, ordered compression lengths, or compressor provenance. Its export therefore records the source filename, object labels, imported symmetric matrix, explicit `imported` provenance, and the resulting QSearch tree without inventing unavailable information.
+
+## Integrity model
+
+Each raw object carries its own SHA-256 digest. The export also computes a SHA-256 digest using the versioned `complearn-export-integrity-v1` contract. Its compact integrity material contains the complete input manifest, source provenance, content hashes and byte lengths, distance analysis, and quartet tree. It omits only the raw text from that second hashing pass because each text is already bound by its object digest; this prevents another full-size copy for large exports. The digest becomes both `integrity.sha256` and the experiment identifier. It detects accidental modification of inputs, provenance, numerical results, or topology. It is not a digital signature and does not establish who produced the file.
+
+Export is fail-fast. A download is blocked if object metadata is out of order, content hashes are unavailable, compressed-size records are incomplete, the directed matrix cannot reproduce the reduced matrix, labels differ across stages, the tree is cyclic or disconnected, an edge-support value is invalid, or the balanced split disagrees with the selected topology.
+
+## Operational limits
+
+Input loading and compression already enforce browser-safe size bounds. Hashing is sequential to avoid multiplying peak memory. The final download still needs one JSON string and one `Blob`; therefore an export containing very large local inputs temporarily requires memory close to the serialized file size. Compact serialization avoids the substantial overhead of indentation. No input, token, API key, account information, browser fingerprint, or cache namespace is sent to a server during export.
+
+The existing **Export DOT** action remains a convenient topology-only interchange format inside the tree viewer. Use **Download JSON** when the data, matrices, provenance, and search metadata must travel with the tree.
+
+## Verification
+
+Focused tests cover complete reconstruction from cache hits and worker results, exact input hashing, computed and imported matrix exports, topology and balanced-split metadata, result integrity, filename stability, and fail-fast rejection of an inconsistent reflected-minimum matrix:
+
+```bash
+npm test -- src/__test__/clusteringExperimentExport.test.ts src/__test__/workbench.test.tsx
+npm run export-schema:verify
+npm run build
+```

--- a/ncd-calculator/package.json
+++ b/ncd-calculator/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run graphviz:verify-dev && npm run workers:verify-dev && npm run udhr:verify && npm run astronomy:verify && vite build && node scripts/verify-production-bundle.mjs",
+    "build": "npm run graphviz:verify-dev && npm run workers:verify-dev && npm run udhr:verify && npm run astronomy:verify && npm run export-schema:verify && vite build && node scripts/verify-production-bundle.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "debug": "vite --debug",
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit",
     "graphviz:verify-dev": "node scripts/verify-dev-graphviz.mjs",
     "workers:verify-dev": "node scripts/verify-dev-compression-workers.mjs",
+    "export-schema:verify": "node scripts/verify-clustering-export-schema.mjs",
     "udhr:audit": "node scripts/build-udhr-corpus.mjs --audit-only",
     "udhr:refresh": "node scripts/build-udhr-corpus.mjs",
     "udhr:verify": "node scripts/verify-udhr-corpus.mjs",

--- a/ncd-calculator/public/schemas/clustering-experiment-v1.schema.json
+++ b/ncd-calculator/public/schemas/clustering-experiment-v1.schema.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rudi-cilibrasi/libqsearch-clean/main/ncd-calculator/public/schemas/clustering-experiment-v1.schema.json",
+  "title": "CompLearn clustering experiment export",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schemaVersion", "schema", "exportedAt", "experiment", "integrity"],
+  "properties": {
+    "format": {"const": "complearn-clustering-experiment"},
+    "schemaVersion": {"const": 1},
+    "schema": {"const": "https://raw.githubusercontent.com/rudi-cilibrasi/libqsearch-clean/main/ncd-calculator/public/schemas/clustering-experiment-v1.schema.json"},
+    "exportedAt": {"type": "string", "format": "date-time"},
+    "experiment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "timing", "input", "distanceAnalysis", "quartetTree"],
+      "properties": {
+        "id": {"$ref": "#/$defs/sha256Key"},
+        "timing": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["startedAt", "completedAt"],
+          "properties": {
+            "startedAt": {"type": "string", "format": "date-time"},
+            "completedAt": {"type": "string", "format": "date-time"}
+          }
+        },
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "sourceFileName", "objectCount", "objects"],
+          "properties": {
+            "kind": {"enum": ["objects", "distance-matrix"]},
+            "sourceFileName": {"type": ["string", "null"]},
+            "objectCount": {"type": "integer", "minimum": 1},
+            "objects": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"$ref": "#/$defs/inputObject"}
+            }
+          }
+        },
+        "distanceAnalysis": {"$ref": "#/$defs/distanceAnalysis"},
+        "quartetTree": {"$ref": "#/$defs/quartetTree"}
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "scope", "canonicalization", "sha256"],
+      "properties": {
+        "algorithm": {"const": "SHA-256"},
+        "scope": {"const": "input-manifest + distance-analysis + quartet-tree"},
+        "canonicalization": {"const": "complearn-export-integrity-v1"},
+        "sha256": {"$ref": "#/$defs/sha256"}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "sha256Key": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "matrix": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "array",
+        "minItems": 1,
+        "items": {"type": "number", "minimum": 0}
+      }
+    },
+    "objectReference": {
+      "type": "object",
+      "required": ["index", "id", "displayLabel"],
+      "properties": {
+        "index": {"type": "integer", "minimum": 0},
+        "id": {"type": "string", "minLength": 1},
+        "displayLabel": {"type": "string", "minLength": 1}
+      }
+    },
+    "source": {
+      "oneOf": [
+        {"type": "object", "required": ["kind", "provenance"], "properties": {"kind": {"const": "genbank"}, "provenance": {"type": "object"}}, "additionalProperties": false},
+        {"type": "object", "required": ["kind", "corpus", "record"], "properties": {"kind": {"const": "udhr"}, "corpus": {"type": "object"}, "record": {"type": "object"}}, "additionalProperties": false},
+        {"type": "object", "required": ["kind", "exampleId"], "properties": {"kind": {"const": "built-in-example"}, "exampleId": {"type": "string", "minLength": 1}}, "additionalProperties": false},
+        {"type": "object", "required": ["kind", "provenance"], "properties": {"kind": {"const": "astronomy"}, "provenance": {"type": "object"}}, "additionalProperties": false},
+        {"type": "object", "required": ["kind", "fileName"], "properties": {"kind": {"const": "local-file"}, "fileName": {"type": "string", "minLength": 1}}, "additionalProperties": false},
+        {"type": "object", "required": ["kind", "fileName"], "properties": {"kind": {"const": "imported-distance-matrix"}, "fileName": {"type": "string", "minLength": 1}}, "additionalProperties": false}
+      ]
+    },
+    "inputObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "id", "displayLabel", "source", "data", "contentKey"],
+      "properties": {
+        "index": {"type": "integer", "minimum": 0},
+        "id": {"type": "string", "minLength": 1},
+        "displayLabel": {"type": "string", "minLength": 1},
+        "source": {"$ref": "#/$defs/source"},
+        "contentKey": {"oneOf": [{"$ref": "#/$defs/sha256Key"}, {"type": "null"}]},
+        "data": {
+          "oneOf": [
+            {"type": "null"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["mediaType", "encoding", "utf8Bytes", "sha256", "text"],
+              "properties": {
+                "mediaType": {"const": "text/plain; charset=utf-8"},
+                "encoding": {"const": "utf-8"},
+                "utf8Bytes": {"type": "integer", "minimum": 0},
+                "sha256": {"$ref": "#/$defs/sha256"},
+                "text": {"type": "string"}
+              }
+            }
+          ]
+        }
+      }
+    },
+    "compressionProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "algorithm", "compressorRevision", "pipelineVersion", "cacheSchemaVersion", "directedMatrixForm", "matrixReduction", "pairSeparator"],
+      "properties": {
+        "source": {"enum": ["computed", "imported"]},
+        "algorithm": {"enum": ["lzma", "zstd", "unknown"]},
+        "compressorRevision": {"type": "string"},
+        "pipelineVersion": {"type": "string"},
+        "cacheSchemaVersion": {"type": "integer", "minimum": 0},
+        "directedMatrixForm": {"enum": ["ordered", "unknown"]},
+        "matrixReduction": {"enum": ["reflected-minimum", "unknown"]},
+        "pairSeparator": {"type": "string"}
+      }
+    },
+    "singleCompressionRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentKey", "compressedSize"],
+      "properties": {
+        "contentKey": {"$ref": "#/$defs/sha256Key"},
+        "compressedSize": {"type": "number", "exclusiveMinimum": 0}
+      }
+    },
+    "pairCompressionRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceContentKey", "targetContentKey", "compressedSize"],
+      "properties": {
+        "sourceContentKey": {"$ref": "#/$defs/sha256Key"},
+        "targetContentKey": {"$ref": "#/$defs/sha256Key"},
+        "compressedSize": {"type": "number", "exclusiveMinimum": 0}
+      }
+    },
+    "distanceAnalysis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["objectOrder", "directedNcdMatrix", "reflectedMinimumNcdMatrix", "compression"],
+      "properties": {
+        "objectOrder": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/objectReference"}},
+        "directedNcdMatrix": {"oneOf": [{"$ref": "#/$defs/matrix"}, {"type": "null"}]},
+        "reflectedMinimumNcdMatrix": {"$ref": "#/$defs/matrix"},
+        "compression": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provenance", "records"],
+          "properties": {
+            "provenance": {"$ref": "#/$defs/compressionProvenance"},
+            "records": {
+              "oneOf": [
+                {"type": "null"},
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["singles", "orderedPairs"],
+                  "properties": {
+                    "singles": {"type": "array", "items": {"$ref": "#/$defs/singleCompressionRecord"}},
+                    "orderedPairs": {"type": "array", "items": {"$ref": "#/$defs/pairCompressionRecord"}}
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "quartetTree": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rooted", "nodes", "edges", "edgeSupport", "balancedSplit", "search"],
+      "properties": {
+        "rooted": {"const": false},
+        "nodes": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/treeNode"}},
+        "edges": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/treeEdge"}},
+        "edgeSupport": {"type": "object", "additionalProperties": {"type": "number", "minimum": 0, "maximum": 1}},
+        "balancedSplit": {"$ref": "#/$defs/balancedSplit"},
+        "search": {"$ref": "#/$defs/searchSummary"}
+      }
+    },
+    "treeNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "kind", "nativeLabel", "objectId", "displayLabel", "connections"],
+      "properties": {
+        "index": {"type": "integer", "minimum": 0},
+        "kind": {"enum": ["leaf", "branch"]},
+        "nativeLabel": {"type": ["string", "null"]},
+        "objectId": {"type": ["string", "null"]},
+        "displayLabel": {"type": ["string", "null"]},
+        "connections": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 0}, "uniqueItems": true}
+      }
+    },
+    "treeEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "target", "support", "supportKind"],
+      "properties": {
+        "source": {"type": "integer", "minimum": 0},
+        "target": {"type": "integer", "minimum": 0},
+        "support": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "supportKind": {"enum": ["repeated-search-stability", null]}
+      }
+    },
+    "balancedSplit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["edgeKey", "leftLeafIndices", "rightLeafIndices", "support", "leftObjects", "rightObjects"],
+      "properties": {
+        "edgeKey": {"type": "string", "pattern": "^[0-9]+-[0-9]+$"},
+        "leftLeafIndices": {"type": "array", "items": {"type": "integer", "minimum": 0}, "uniqueItems": true},
+        "rightLeafIndices": {"type": "array", "items": {"type": "integer", "minimum": 0}, "uniqueItems": true},
+        "support": {"type": "number", "minimum": 0, "maximum": 1},
+        "leftObjects": {"type": "array", "items": {"$ref": "#/$defs/objectReference"}},
+        "rightObjects": {"type": "array", "items": {"$ref": "#/$defs/objectReference"}}
+      }
+    },
+    "searchSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pipelineVersion", "runCount", "baseSeed", "selectedSeed", "selectedScore", "scoreMinimum", "scoreMean", "scoreMaximum", "selectedTopologyCount", "selectedTopologySupport", "uniqueTopologyCount", "supportKind"],
+      "properties": {
+        "pipelineVersion": {"type": "string", "minLength": 1},
+        "runCount": {"type": "integer", "minimum": 1},
+        "baseSeed": {"type": "integer", "minimum": 0, "maximum": 4294967295},
+        "selectedSeed": {"type": "integer", "minimum": 0, "maximum": 4294967295},
+        "selectedScore": {"type": "number"},
+        "scoreMinimum": {"type": "number"},
+        "scoreMean": {"type": "number"},
+        "scoreMaximum": {"type": "number"},
+        "selectedTopologyCount": {"type": "integer", "minimum": 1},
+        "selectedTopologySupport": {"type": "number", "minimum": 0, "maximum": 1},
+        "uniqueTopologyCount": {"type": "integer", "minimum": 1},
+        "supportKind": {"const": "repeated-search-stability"}
+      }
+    }
+  }
+}

--- a/ncd-calculator/scripts/verify-clustering-export-schema.mjs
+++ b/ncd-calculator/scripts/verify-clustering-export-schema.mjs
@@ -1,0 +1,45 @@
+import {readFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+
+const schemaUrl = new URL("../public/schemas/clustering-experiment-v1.schema.json", import.meta.url);
+const schema = JSON.parse(await readFile(schemaUrl, "utf8"));
+const expectedId = "https://raw.githubusercontent.com/rudi-cilibrasi/libqsearch-clean/main/ncd-calculator/public/schemas/clustering-experiment-v1.schema.json";
+
+if (
+  schema.$schema !== "https://json-schema.org/draft/2020-12/schema"
+  || schema.$id !== expectedId
+  || schema.properties?.format?.const !== "complearn-clustering-experiment"
+  || schema.properties?.schemaVersion?.const !== 1
+  || schema.properties?.schema?.const !== expectedId
+) {
+  throw new Error("Clustering export schema identity does not match format version 1");
+}
+
+const definitions = schema.$defs;
+if (!definitions || typeof definitions !== "object") {
+  throw new Error("Clustering export schema has no definitions");
+}
+
+const visit = (value, location = "#") => {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => visit(entry, `${location}/${index}`));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  if (typeof value.$ref === "string" && value.$ref.startsWith("#/$defs/")) {
+    const definitionName = value.$ref.slice("#/$defs/".length);
+    if (!Object.hasOwn(definitions, definitionName)) {
+      throw new Error(`Clustering export schema has an unresolved reference at ${location}: ${value.$ref}`);
+    }
+  }
+  Object.entries(value).forEach(([key, entry]) => visit(entry, `${location}/${key}`));
+};
+visit(schema);
+
+for (const requiredDefinition of ["inputObject", "distanceAnalysis", "quartetTree", "searchSummary"]) {
+  if (!Object.hasOwn(definitions, requiredDefinition)) {
+    throw new Error(`Clustering export schema is missing ${requiredDefinition}`);
+  }
+}
+
+console.log(`Verified clustering export schema: ${fileURLToPath(schemaUrl)}`);

--- a/ncd-calculator/src/__test__/clusteringExperimentExport.test.ts
+++ b/ncd-calculator/src/__test__/clusteringExperimentExport.test.ts
@@ -1,0 +1,221 @@
+import {webcrypto} from "node:crypto";
+import {beforeAll, describe, expect, test, vi} from "vitest";
+import {
+  buildClusteringExperimentExport,
+  collectCompleteCompressionRecords,
+  getClusteringExperimentFilename,
+  getClusteringExperimentIntegrityMaterial,
+  serializeClusteringExperimentExport,
+} from "@/services/ClusteringExperimentExport";
+import {
+  createPairCacheKey,
+  createSingleCacheKey,
+  fingerprintContent,
+  getCompressionProvenance,
+  IMPORTED_MATRIX_PROVENANCE,
+  reduceDirectedMatrix,
+} from "@/services/CompressionProtocol";
+import type {ExperimentInputObjectMetadata} from "@/types/experiment";
+import type {NCDInput} from "@/types/ncd";
+import type {QTreeResponse} from "@/types/qsearch";
+
+const CONTENTS = ["alpha", "beta", "gamma", "delta"];
+const LABELS = ["object-a", "object-b", "object-c", "object-d"];
+const DISPLAY_LABELS = ["Alpha", "Beta", "Gamma", "Delta"];
+const DIRECTED_MATRIX = [
+  [0, 0.1, 0.8, 0.9],
+  [0.2, 0, 0.7, 0.8],
+  [0.9, 0.8, 0, 0.1],
+  [0.8, 0.9, 0.2, 0],
+];
+const TIMING = {
+  startedAt: "2026-08-08T08:00:00.000Z",
+  completedAt: "2026-08-08T08:01:00.000Z",
+};
+const EXPORTED_AT = "2026-08-08T08:02:03.456Z";
+
+const TREE: QTreeResponse = {
+  nodes: [
+    {index: 0, label: LABELS[0], connections: [4]},
+    {index: 1, label: LABELS[1], connections: [4]},
+    {index: 2, label: LABELS[2], connections: [5]},
+    {index: 3, label: LABELS[3], connections: [5]},
+    {index: 4, label: "node 4", connections: [0, 1, 5]},
+    {index: 5, label: "node 5", connections: [2, 3, 4]},
+  ],
+  edgeSupport: {"4-5": 1},
+  balancedSplit: {
+    edgeKey: "4-5",
+    leftLeafIndices: [0, 1],
+    rightLeafIndices: [2, 3],
+    support: 1,
+  },
+  search: {
+    pipelineVersion: "qsearch-multistart-v2",
+    runCount: 16,
+    baseSeed: 123,
+    selectedSeed: 456,
+    selectedScore: 0.99,
+    scoreMinimum: 0.9,
+    scoreMean: 0.95,
+    scoreMaximum: 0.99,
+    selectedTopologyCount: 16,
+    selectedTopologySupport: 1,
+    uniqueTopologyCount: 1,
+    supportKind: "repeated-search-stability",
+  },
+};
+
+const objectMetadata = (): ExperimentInputObjectMetadata[] => LABELS.map((id, index) => ({
+  id,
+  displayLabel: DISPLAY_LABELS[index],
+  source: {kind: "built-in-example", exampleId: id},
+}));
+
+const computedFixture = async () => {
+  const contentKeys = await Promise.all(CONTENTS.map(fingerprintContent));
+  const singles = contentKeys.map((contentKey) => ({contentKey, compressedSize: 100}));
+  const orderedPairs = contentKeys.flatMap((sourceContentKey, source) => (
+    contentKeys.flatMap((targetContentKey, target) => source === target ? [] : [{
+      sourceContentKey,
+      targetContentKey,
+      compressedSize: 100 + (DIRECTED_MATRIX[source][target] * 100),
+    }])
+  ));
+  const compressionRecords = collectCompleteCompressionRecords({
+    algorithm: "lzma",
+    contentKeys,
+    cachedSizes: new Map(),
+    newSingles: singles,
+    newOrderedPairs: orderedPairs,
+  });
+  const input: NCDInput = {
+    labels: [...LABELS],
+    displayLabels: [...DISPLAY_LABELS],
+    contents: [...CONTENTS],
+    kind: "objects",
+    objectMetadata: objectMetadata(),
+  };
+  return {contentKeys, compressionRecords, input};
+};
+
+describe("clustering experiment JSON export", () => {
+  beforeAll(() => vi.stubGlobal("crypto", webcrypto));
+
+  test("exports reproducible inputs, compression records, matrices, and tree metadata", async () => {
+    const {contentKeys, compressionRecords, input} = await computedFixture();
+    const exported = await buildClusteringExperimentExport({
+      input,
+      matrix: {
+        labels: [...LABELS],
+        directedNcdMatrix: DIRECTED_MATRIX,
+        ncdMatrix: reduceDirectedMatrix(DIRECTED_MATRIX),
+        provenance: getCompressionProvenance("lzma"),
+      },
+      compressionRecords,
+      tree: TREE,
+      timing: TIMING,
+      exportedAt: EXPORTED_AT,
+    });
+
+    expect(exported.format).toBe("complearn-clustering-experiment");
+    expect(exported.schemaVersion).toBe(1);
+    expect(exported.experiment.input.objects).toHaveLength(4);
+    expect(exported.experiment.input.objects[0]).toMatchObject({
+      id: "object-a",
+      displayLabel: "Alpha",
+      contentKey: contentKeys[0],
+      data: {text: "alpha", utf8Bytes: 5},
+    });
+    expect(exported.experiment.distanceAnalysis.compression.records?.singles).toHaveLength(4);
+    expect(exported.experiment.distanceAnalysis.compression.records?.orderedPairs).toHaveLength(12);
+    expect(exported.experiment.distanceAnalysis.directedNcdMatrix).toEqual(DIRECTED_MATRIX);
+    expect(exported.experiment.quartetTree.rooted).toBe(false);
+    expect(exported.experiment.quartetTree.balancedSplit.leftObjects.map(({id}) => id))
+      .toEqual(["object-a", "object-b"]);
+    expect(exported.experiment.quartetTree.edges.find(({source, target}) => source === 4 && target === 5))
+      .toMatchObject({support: 1, supportKind: "repeated-search-stability"});
+
+    const resultMaterial = getClusteringExperimentIntegrityMaterial(
+      exported.experiment.input,
+      exported.experiment.distanceAnalysis,
+      exported.experiment.quartetTree,
+    );
+    expect(exported.integrity.sha256).toBe((await fingerprintContent(resultMaterial)).slice("sha256:".length));
+    expect(exported.experiment.id).toBe(`sha256:${exported.integrity.sha256}`);
+    expect(serializeClusteringExperimentExport(exported)).not.toContain("\n");
+    expect(getClusteringExperimentFilename(EXPORTED_AT)).toBe("complearn-clustering-20260808T080203Z.json");
+  });
+
+  test("reconstructs a complete record set from cache hits and worker misses", async () => {
+    const contentKeys = await Promise.all(CONTENTS.slice(0, 2).map(fingerprintContent));
+    const cache = new Map<string, number>([
+      [createSingleCacheKey("lzma", contentKeys[0]), 100],
+      [createPairCacheKey("lzma", contentKeys[0], contentKeys[1]), 120],
+    ]);
+    const records = collectCompleteCompressionRecords({
+      algorithm: "lzma",
+      contentKeys,
+      cachedSizes: cache,
+      newSingles: [{contentKey: contentKeys[1], compressedSize: 110}],
+      newOrderedPairs: [{
+        sourceContentKey: contentKeys[1],
+        targetContentKey: contentKeys[0],
+        compressedSize: 121,
+      }],
+    });
+
+    expect(records.singles.map(({compressedSize}) => compressedSize)).toEqual([100, 110]);
+    expect(records.orderedPairs.map(({compressedSize}) => compressedSize)).toEqual([120, 121]);
+  });
+
+  test("exports an imported matrix without inventing raw inputs or compressor metadata", async () => {
+    const ncdMatrix = reduceDirectedMatrix(DIRECTED_MATRIX);
+    const input: NCDInput = {
+      labels: [...LABELS],
+      displayLabels: [...DISPLAY_LABELS],
+      contents: ncdMatrix.map((row) => JSON.stringify(row)),
+      kind: "distance-matrix",
+      sourceFileName: "published-distances.json",
+      objectMetadata: LABELS.map((id, index) => ({
+        id,
+        displayLabel: DISPLAY_LABELS[index],
+        source: {kind: "imported-distance-matrix", fileName: "published-distances.json"},
+      })),
+    };
+    const exported = await buildClusteringExperimentExport({
+      input,
+      matrix: {labels: [...LABELS], ncdMatrix, provenance: IMPORTED_MATRIX_PROVENANCE},
+      compressionRecords: null,
+      tree: TREE,
+      timing: TIMING,
+      exportedAt: EXPORTED_AT,
+    });
+
+    expect(exported.experiment.input.sourceFileName).toBe("published-distances.json");
+    expect(exported.experiment.input.objects.every(({data, contentKey}) => data === null && contentKey === null)).toBe(true);
+    expect(exported.experiment.distanceAnalysis.directedNcdMatrix).toBeNull();
+    expect(exported.experiment.distanceAnalysis.compression.records).toBeNull();
+    expect(exported.experiment.distanceAnalysis.compression.provenance.source).toBe("imported");
+  });
+
+  test("fails rather than exporting internally inconsistent results", async () => {
+    const {compressionRecords, input} = await computedFixture();
+    const invalidReduced = reduceDirectedMatrix(DIRECTED_MATRIX);
+    invalidReduced[0][1] = invalidReduced[1][0] = 0.5;
+
+    await expect(buildClusteringExperimentExport({
+      input,
+      matrix: {
+        labels: [...LABELS],
+        directedNcdMatrix: DIRECTED_MATRIX,
+        ncdMatrix: invalidReduced,
+        provenance: getCompressionProvenance("lzma"),
+      },
+      compressionRecords,
+      tree: TREE,
+      timing: TIMING,
+      exportedAt: EXPORTED_AT,
+    })).rejects.toThrow("Reflected-minimum matrix does not match");
+  });
+});

--- a/ncd-calculator/src/__test__/workbench.test.tsx
+++ b/ncd-calculator/src/__test__/workbench.test.tsx
@@ -195,6 +195,37 @@ describe("NCD workbench", () => {
         expect(compressionWorkerLifecycleMocks.initialize).not.toHaveBeenCalled();
     });
 
+    test("passes source metadata with the built-in comparison set", async () => {
+        const onComputedNcdInput = vi.fn();
+        render(
+            <MemoryRouter>
+                <ListEditor
+                    onComputedNcdInput={onComputedNcdInput}
+                    setIsLoading={vi.fn()}
+                    resetDisplay={vi.fn()}
+                    setOpenLogin={vi.fn()}
+                    authenticated={false}
+                />
+            </MemoryRouter>
+        );
+
+        fireEvent.click(screen.getByRole("button", {name: "Sequence example"}));
+        fireEvent.click(screen.getByRole("button", {name: "Show Similarity"}));
+
+        await waitFor(() => expect(onComputedNcdInput).toHaveBeenCalledOnce());
+        expect(onComputedNcdInput).toHaveBeenCalledWith(expect.objectContaining({
+            kind: "objects",
+            objectMetadata: expect.arrayContaining([
+                expect.objectContaining({
+                    id: "example-alpha",
+                    displayLabel: "Sequence alpha",
+                    source: {kind: "built-in-example", exampleId: "example-alpha"},
+                }),
+            ]),
+        }));
+        expect(screen.queryByRole("button", {name: "Export tree"})).not.toBeInTheDocument();
+    });
+
     test("upgrades saved UDHR identifiers to canonical language names", async () => {
         localStorage.setItem(STORAGE_VERSION_NAME, STORAGE_VERSION.toString());
         localStorage.setItem("searchMode", JSON.stringify({searchMode: FASTA}));

--- a/ncd-calculator/src/components/ListEditor.tsx
+++ b/ncd-calculator/src/components/ListEditor.tsx
@@ -12,11 +12,12 @@
  */
 
 import React, {useEffect, useRef, useState} from "react";
-import {AlertCircle, Dna, Download, FileType2, FlaskConical, Globe2, Telescope, Upload} from "lucide-react";
+import {AlertCircle, Dna, FileType2, FlaskConical, Globe2, Telescope, Upload} from "lucide-react";
 import {
 	getTranslationResponse,
 	getUdhrLanguage,
 	getUdhrRecordDisplayLabel,
+	UDHR_CORPUS,
 } from "../functions/udhr";
 import {InputHolder} from "./InputHolder.tsx";
 import {Language} from "./Language";
@@ -27,10 +28,8 @@ import {LocalStorageKeyManager, LocalStorageKeys} from "../cache/LocalStorageKey
 import {getFastaSequences} from "../functions/getPublicGenbank";
 import {FASTA, FILE_UPLOAD, LANGUAGE} from "../constants/modalConstants";
 import {useSearchParams} from "react-router-dom";
-import {NCDImportFormat} from "@/types/ncd";
-import createGraph from "@/functions/graphExport.ts";
-import {saveAs} from "file-saver";
-import type {QTreeResponse} from "@/types/qsearch";
+import type {NCDImportFormat, NCDInput} from "@/types/ncd";
+import type {ExperimentInputObjectMetadata, ExperimentObjectSource} from "@/types/experiment";
 import {getWorkbenchExampleItems} from "./workbenchExamples";
 import type {SelectedItem} from "./workbenchTypes";
 import {
@@ -44,13 +43,6 @@ export interface SearchMode {
 	searchMode: string;
 }
 
-export interface NcdInput {
-	labels: string[];
-	displayLabels?: string[];
-	contents: string[];
-	kind?: "objects" | "distance-matrix";
-}
-
 const getItemDisplayLabel = (item: SelectedItem): string => {
 	if (item.type === LANGUAGE) {
 		return getUdhrRecordDisplayLabel(item.id) ?? item.label ?? item.id;
@@ -58,14 +50,68 @@ const getItemDisplayLabel = (item: SelectedItem): string => {
 	return item.label?.trim() || item.id;
 };
 
+const getExperimentObjectSource = (
+	item: SelectedItem,
+	kind: "objects" | "distance-matrix",
+	importedMatrixFileName?: string,
+): ExperimentObjectSource => {
+	if (kind === "distance-matrix") {
+		return {
+			kind: "imported-distance-matrix",
+			fileName: importedMatrixFileName?.trim() || "imported-matrix.json",
+		};
+	}
+	if (item.type === LANGUAGE) {
+		const record = getUdhrLanguage(item.id);
+		if (!record) throw new Error(`Missing UDHR provenance for ${item.id}`);
+		return {
+			kind: "udhr",
+			corpus: {
+				schemaVersion: UDHR_CORPUS.schemaVersion,
+				corpusVersion: UDHR_CORPUS.corpusVersion,
+				assetBasePath: UDHR_CORPUS.assetBasePath,
+				source: {...UDHR_CORPUS.source},
+				summary: {...UDHR_CORPUS.summary},
+			},
+			record: {
+				...record,
+				articleNumbers: [...record.articleNumbers],
+				comparisonExclusionReasons: [...record.comparisonExclusionReasons],
+			},
+		};
+	}
+	if (item.type === FASTA) {
+		if (!item.genBankProvenance) {
+			throw new Error(`Missing verified GenBank provenance for ${item.id}`);
+		}
+		return {kind: "genbank", provenance: {...item.genBankProvenance}};
+	}
+	if (item.astronomyProvenance) {
+		return {kind: "astronomy", provenance: {...item.astronomyProvenance}};
+	}
+	if (item.id.startsWith("example-")) {
+		return {kind: "built-in-example", exampleId: item.id};
+	}
+	return {kind: "local-file", fileName: item.id};
+};
+
+const getExperimentObjectMetadata = (
+	items: readonly SelectedItem[],
+	kind: "objects" | "distance-matrix",
+	importedMatrixFileName?: string,
+): ExperimentInputObjectMetadata[] => items.map((item) => ({
+	id: item.id,
+	displayLabel: getItemDisplayLabel(item),
+	source: getExperimentObjectSource(item, kind, importedMatrixFileName),
+}));
+
 interface ListEditorProps {
-	onComputedNcdInput: (input: NcdInput) => void;
+	onComputedNcdInput: (input: NCDInput) => void;
 	setIsLoading: (loading: boolean) => void;
 	resetDisplay: () => void;
 	setOpenLogin: (open: boolean) => void;
 	authenticated: boolean;
 	initialSearchMode?: SearchMode | null;
-	qTreeResponse?: QTreeResponse | null;
 }
 
 const ListEditor: React.FC<ListEditorProps> = ({
@@ -73,7 +119,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	                                               setIsLoading,
 	                                               resetDisplay,
 	                                               initialSearchMode,
-	                                               qTreeResponse
                                                }) => {
 	
 	const [importError, setImportError] = React.useState<string | null>(null);
@@ -81,6 +126,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	const [hasImportedMatrix, setHasImportedMatrix] = useState<boolean>(false);
 	const [isAutoProcessing, setIsAutoProcessing] = useState<boolean>(false);
 	const [isLoadingAstronomy, setIsLoadingAstronomy] = useState<boolean>(false);
+	const [importedMatrixFileName, setImportedMatrixFileName] = useState<string | null>(null);
 	
 	
 	const triggerFileInput = () => {
@@ -134,6 +180,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 			
 			// Update selected items
 			setSelectedItems(importedItems);
+			setImportedMatrixFileName(file.name);
 			
 			// Set flag that we've imported a matrix
 			setHasImportedMatrix(true);
@@ -145,7 +192,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 				fileInputRef.current.value = '';
 			}
 			
-			await processImportedMatrix(importedItems);
+			await processImportedMatrix(importedItems, file.name);
 			
 		} catch (err) {
 			console.error('Error importing file:', err);
@@ -159,7 +206,10 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	};
 	
 	
-	const processImportedMatrix = async (importedItems: SelectedItem[]): Promise<void> => {
+	const processImportedMatrix = async (
+		importedItems: SelectedItem[],
+		sourceFileName: string,
+	): Promise<void> => {
 		try {
 			console.log("Automatically processing imported matrix data...");
 			setIsLoading(true);
@@ -178,6 +228,8 @@ const ListEditor: React.FC<ListEditorProps> = ({
 				displayLabels: importedItems.map(getItemDisplayLabel),
 				contents,
 				kind: "distance-matrix",
+				objectMetadata: getExperimentObjectMetadata(importedItems, "distance-matrix", sourceFileName),
+				sourceFileName,
 			});
 			console.log("Automatic processing of imported matrix complete");
 		} catch (error) {
@@ -188,14 +240,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 		}
 	};
 	
-	
-	const handleExportMatrix = (): void => {
-		
-		const dotFormat = createGraph(qTreeResponse as Parameters<typeof createGraph>[0], false);
-		
-		const blob = new Blob([dotFormat], {type: "text/plain;charset=utf-8"});
-		saveAs(blob, "matrix_structure.dot");
-	};
 	
 	const defaultSearchMode = {
 		searchMode: initialSearchMode?.searchMode || FASTA
@@ -285,6 +329,12 @@ const ListEditor: React.FC<ListEditorProps> = ({
 					displayLabels: selectedItems.map(getItemDisplayLabel),
 					contents,
 					kind: "distance-matrix",
+					objectMetadata: getExperimentObjectMetadata(
+						selectedItems,
+						"distance-matrix",
+						importedMatrixFileName ?? undefined,
+					),
+					sourceFileName: importedMatrixFileName ?? "imported-matrix.json",
 				});
 			} else {
 				const computedNcdInput = await computeNcdInput(selectedItems);
@@ -298,7 +348,8 @@ const ListEditor: React.FC<ListEditorProps> = ({
 					displayLabels: ncdSelectedItems.map(getItemDisplayLabel),
 					contents: ncdSelectedItems.map((item) => item.content || ""),
 					kind: "objects",
-				} as NcdInput;
+					objectMetadata: getExperimentObjectMetadata(ncdSelectedItems, "objects"),
+				} satisfies NCDInput;
 				await onComputedNcdInput(input);
 			}
 		} catch (error) {
@@ -360,6 +411,9 @@ const ListEditor: React.FC<ListEditorProps> = ({
 			const item = itemMap.get(computed.id);
 			if (item && computed.content) {
 				item.content = computed.content;
+				if (computed.genBankProvenance) {
+					item.genBankProvenance = computed.genBankProvenance;
+				}
 			}
 		})
 		
@@ -520,6 +574,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 		setSelectedItems([]);
 		resetDisplay();
 		setHasImportedMatrix(false);
+		setImportedMatrixFileName(null);
 		setImportError(null);
 		if (currentMode) {
 			setSearchParams({searchMode: currentMode});
@@ -536,6 +591,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 		setMode(FILE_UPLOAD);
 		setSelectedItems(examples);
 		setHasImportedMatrix(false);
+		setImportedMatrixFileName(null);
 		setImportError(null);
 	};
 
@@ -548,6 +604,7 @@ const ListEditor: React.FC<ListEditorProps> = ({
 			setMode(FILE_UPLOAD);
 			setSelectedItems(examples);
 			setHasImportedMatrix(false);
+			setImportedMatrixFileName(null);
 		} catch (error) {
 			setImportError(error instanceof Error ? error.message : "Unable to load the astronomy example");
 		} finally {
@@ -635,10 +692,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 					<button type="button" onClick={triggerFileInput} className="workbench-button">
 						<Upload size={17} aria-hidden="true"/>
 						Import matrix
-					</button>
-					<button type="button" onClick={handleExportMatrix} className="workbench-button" disabled={selectedItems.length === 0}>
-						<Download size={17} aria-hidden="true"/>
-						Export tree
 					</button>
 				</div>
 				<div className="workbench-actions__primary">

--- a/ncd-calculator/src/components/QSearch.tsx
+++ b/ncd-calculator/src/components/QSearch.tsx
@@ -13,6 +13,8 @@
  */
 
 import React, {useEffect, useRef, useState} from "react";
+import {Download} from "lucide-react";
+import {saveAs} from "file-saver";
 // @ts-ignore
 import QSearchWorker from "../workers/qsearchWorker.js?worker";
 import ListEditor from "./ListEditor";
@@ -30,6 +32,13 @@ import {IMPORTED_MATRIX_PROVENANCE} from "@/services/CompressionProtocol";
 import type {CompressionProvenance} from "@/types/compression";
 import {getQSearchRunCount} from "@/services/QSearchProtocol";
 import {createDisplayLabelMap, getDisplayLabel} from "@/services/DisplayLabelProtocol";
+import {
+	buildClusteringExperimentExport,
+	collectCompleteCompressionRecords,
+	getClusteringExperimentFilename,
+	serializeClusteringExperimentExport,
+} from "@/services/ClusteringExperimentExport";
+import type {ClusteringExperimentTiming, CompleteCompressionRecords} from "@/types/experiment";
 import "./Workbench.css";
 
 export interface QSearchProps {
@@ -51,11 +60,17 @@ export const QSearch: React.FC<QSearchProps> = ({
 	const [hasMatrix, setHasMatrix] = useState(false);
 	const [errorMsg, setErrorMsg] = useState("");
 	const [qSearchTreeResult, setQSearchTreeResult] = useState<QTreeResponse | undefined>();
+	const [rawQSearchTreeResult, setRawQSearchTreeResult] = useState<QTreeResponse | undefined>();
 	const [qSearchProgress, setQSearchProgress] = useState<{completed: number; total: number} | null>(null);
 	const [matrixProvenance, setMatrixProvenance] = useState<CompressionProvenance>(IMPORTED_MATRIX_PROVENANCE);
 	const [labelMap, setLabelMap] = useState<Map<string, string>>(new Map());
 	const labelMapRef = useRef(labelMap);
 	const [isLoading, setIsLoading] = useState(false);
+	const [isExporting, setIsExporting] = useState(false);
+	const [currentInput, setCurrentInput] = useState<NCDInput | null>(null);
+	const [compressionRecords, setCompressionRecords] = useState<CompleteCompressionRecords | null>(null);
+	const [experimentTiming, setExperimentTiming] = useState<ClusteringExperimentTiming | null>(null);
+	const experimentStartedAtRef = useRef<string | null>(null);
 	
 	// Add gridObjects state for KGridVisualization
 	const [gridObjects, setGridObjects] = useState<GridObject[]>([]);
@@ -82,6 +97,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 		if (event.data.action === "treeJSON") {
 			try {
 				const parsed = JSON.parse(event.data.result) as QTreeResponse;
+				setRawQSearchTreeResult(parsed);
 				const result: QTreeResponse = {
 					...parsed,
 					nodes: parsed.nodes.map((node: QTreeNode) => ({
@@ -90,6 +106,11 @@ export const QSearch: React.FC<QSearchProps> = ({
 					})),
 				};
 				setQSearchTreeResult(result);
+				const completedAt = new Date().toISOString();
+				setExperimentTiming({
+					startedAt: experimentStartedAtRef.current ?? completedAt,
+					completedAt,
+				});
 				setQSearchProgress(null);
 				setIsLoading(false);
 			} catch (error) {
@@ -149,6 +170,10 @@ export const QSearch: React.FC<QSearchProps> = ({
 		
 		try {
 			const computationInput: NCDInput = {...input, labels: normalizedLabels};
+			const startedAt = new Date().toISOString();
+			experimentStartedAtRef.current = startedAt;
+			setCurrentInput(computationInput);
+			setExperimentTiming(null);
 			const nextLabelMap = createDisplayLabelMap(normalizedLabels, input.displayLabels);
 			labelMapRef.current = nextLabelMap;
 			setLabelMap(nextLabelMap);
@@ -156,8 +181,10 @@ export const QSearch: React.FC<QSearchProps> = ({
 			setIsLoading(true);
 			setErrorMsg("");
 			setQSearchTreeResult(undefined);
+			setRawQSearchTreeResult(undefined);
 			setQSearchProgress(null);
 			setCompressionInfo(null);
+			setCompressionRecords(null);
 			setCompressionStats({
 				processedPairs: 0,
 				totalPairs: 0,
@@ -207,6 +234,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 					ncdMatrix: ncdMatrix,
 				});
 				setCompressionInfo(null);
+				setCompressionRecords(null);
 			} else {
 				const emptyObjectIndex = computationInput.contents.findIndex(
 					(content) => typeof content !== "string" || content.trim().length === 0,
@@ -260,6 +288,14 @@ export const QSearch: React.FC<QSearchProps> = ({
 				if (!result) {
 					throw new Error("Processing failed");
 				}
+				const completeRecords = collectCompleteCompressionRecords({
+					algorithm: prepared.algorithm,
+					contentKeys: prepared.contentKeys,
+					cachedSizes: prepared.cachedSizes,
+					newSingles: result.singleCompressionData,
+					newOrderedPairs: result.pairCompressionData,
+				});
+				setCompressionRecords(completeRecords);
 				
 				// Display results
 				const response: NCDMatrixResponse = result;
@@ -290,6 +326,47 @@ export const QSearch: React.FC<QSearchProps> = ({
 			console.error("Error in onNcdInput:", error);
 			setErrorMsg(error instanceof Error ? error.message : "Processing failed");
 			setIsLoading(false);
+		}
+	};
+
+	const exportExperiment = async (): Promise<void> => {
+		if (
+			!currentInput
+			|| !rawQSearchTreeResult
+			|| !experimentTiming
+			|| labels.length === 0
+			|| ncdMatrix.length === 0
+		) {
+			setErrorMsg("The clustering result is not ready to export");
+			return;
+		}
+		setIsExporting(true);
+		setErrorMsg("");
+		try {
+			const exportedAt = new Date().toISOString();
+			const document = await buildClusteringExperimentExport({
+				input: currentInput,
+				matrix: {
+					labels,
+					directedNcdMatrix,
+					ncdMatrix,
+					provenance: matrixProvenance,
+				},
+				compressionRecords,
+				tree: rawQSearchTreeResult,
+				timing: experimentTiming,
+				exportedAt,
+			});
+			const blob = new Blob(
+				[serializeClusteringExperimentExport(document)],
+				{type: "application/json;charset=utf-8"},
+			);
+			saveAs(blob, getClusteringExperimentFilename(exportedAt));
+		} catch (error) {
+			console.error("Unable to export clustering experiment:", error);
+			setErrorMsg(error instanceof Error ? error.message : "Unable to export the clustering result");
+		} finally {
+			setIsExporting(false);
 		}
 	};
 
@@ -339,9 +416,14 @@ export const QSearch: React.FC<QSearchProps> = ({
 		setLabelMap(new Map());
 		setHasMatrix(false);
 		setQSearchTreeResult(undefined);
+		setRawQSearchTreeResult(undefined);
 		setQSearchProgress(null);
 		setMatrixProvenance(IMPORTED_MATRIX_PROVENANCE);
 		setCompressionInfo(null);
+		setCompressionRecords(null);
+		setCurrentInput(null);
+		setExperimentTiming(null);
+		experimentStartedAtRef.current = null;
 		setCompressionStats({
 			processedPairs: 0,
 			totalPairs: 0,
@@ -363,7 +445,6 @@ export const QSearch: React.FC<QSearchProps> = ({
 			/>
 			<main className="workbench-page">
 				<ListEditor
-					qTreeResponse={qSearchTreeResult}
 					onComputedNcdInput={onNcdInput}
 					setIsLoading={setIsLoading}
 					resetDisplay={resetDisplay}
@@ -389,7 +470,18 @@ export const QSearch: React.FC<QSearchProps> = ({
 					<section className="workbench-results" aria-labelledby="results-title">
 						<header className="workbench-results__header">
 							<h2 id="results-title">Similarity</h2>
-							<span>{labels.length} objects · {labels.length * (labels.length - 1) / 2} pairs</span>
+							<div className="workbench-results__summary">
+								<span>{labels.length} objects · {labels.length * (labels.length - 1) / 2} pairs</span>
+								<button
+									type="button"
+									onClick={exportExperiment}
+									disabled={!rawQSearchTreeResult || !experimentTiming || isExporting}
+									className="workbench-button workbench-results__export"
+								>
+									<Download size={16} aria-hidden="true"/>
+									{isExporting ? "Preparing JSON…" : "Download JSON"}
+								</button>
+							</div>
 						</header>
 						<KGridVisualization
 							labelMap={labelMap}

--- a/ncd-calculator/src/components/Workbench.css
+++ b/ncd-calculator/src/components/Workbench.css
@@ -658,11 +658,22 @@
     letter-spacing: -0.035em;
 }
 
-.workbench-results__header > span {
+.workbench-results__summary {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 14px;
+}
+
+.workbench-results__summary > span {
     color: var(--ink-muted);
     font-family: var(--font-mono);
     font-size: 0.72rem;
     font-weight: 600;
+}
+
+.workbench-results__export {
+	white-space: nowrap;
 }
 
 .ncd-visualization {
@@ -1205,6 +1216,12 @@ button.genbank-suggestions__status:hover {
         align-items: flex-start;
         flex-direction: column;
     }
+
+	.workbench-results__summary {
+		width: 100%;
+		justify-content: space-between;
+		flex-wrap: wrap;
+	}
 
     .workbench-sourcebar {
         align-items: stretch;

--- a/ncd-calculator/src/services/ClusteringExperimentExport.ts
+++ b/ncd-calculator/src/services/ClusteringExperimentExport.ts
@@ -1,0 +1,483 @@
+import {validateMatrix} from "@/functions/matrix";
+import {
+  createPairCacheKey,
+  createSingleCacheKey,
+  fingerprintContent,
+  reduceDirectedMatrix,
+} from "@/services/CompressionProtocol";
+import {extractTreeSplits, getBalancedTreeSplit} from "@/services/QSearchProtocol";
+import type {CompressionAlgorithm, PairCompressionRecord, SingleCompressionRecord} from "@/types/compression";
+import type {
+  ClusteringExperimentExport,
+  ClusteringExperimentTiming,
+  CompleteCompressionRecords,
+  ExportedBalancedSplit,
+  ExportedExperimentObject,
+  ExportedTreeEdge,
+  ExportedTreeNode,
+} from "@/types/experiment";
+import type {NCDInput, NCDMatrixResponse} from "@/types/ncd";
+import {getTreeEdgeKey, type QTreeResponse} from "@/types/qsearch";
+
+export const CLUSTERING_EXPERIMENT_FORMAT = "complearn-clustering-experiment" as const;
+export const CLUSTERING_EXPERIMENT_SCHEMA_VERSION = 1 as const;
+export const CLUSTERING_EXPERIMENT_SCHEMA_URL =
+  "https://raw.githubusercontent.com/rudi-cilibrasi/libqsearch-clean/main/ncd-calculator/public/schemas/clustering-experiment-v1.schema.json";
+
+const MATRIX_TOLERANCE = 1e-12;
+const SHA256_PREFIX = "sha256:";
+
+const isValidCompressionSize = (value: number): boolean => Number.isFinite(value) && value > 0;
+
+const calculateNcd = (sizeX: number, sizeY: number, sizeXY: number): number => (
+  Math.max((sizeXY - Math.min(sizeX, sizeY)) / Math.max(sizeX, sizeY), 0)
+);
+
+interface CompleteCompressionRecordInput {
+  readonly algorithm: CompressionAlgorithm;
+  readonly contentKeys: readonly string[];
+  readonly cachedSizes: ReadonlyMap<string, number>;
+  readonly newSingles: readonly SingleCompressionRecord[];
+  readonly newOrderedPairs: readonly PairCompressionRecord[];
+}
+
+interface BuildClusteringExperimentInput {
+  readonly input: NCDInput;
+  readonly matrix: NCDMatrixResponse;
+  readonly compressionRecords: CompleteCompressionRecords | null;
+  readonly tree: QTreeResponse;
+  readonly timing: ClusteringExperimentTiming;
+  readonly exportedAt?: string;
+}
+
+const assertIsoTimestamp = (value: string, field: string): void => {
+  if (!value || !Number.isFinite(Date.parse(value))) {
+    throw new Error(`${field} must be an ISO-8601 timestamp`);
+  }
+};
+
+const sha256 = async (value: string): Promise<string> => {
+  const fingerprint = await fingerprintContent(value);
+  if (!fingerprint.startsWith(SHA256_PREFIX)) throw new Error("SHA-256 fingerprint has an invalid format");
+  return fingerprint.slice(SHA256_PREFIX.length);
+};
+
+const cloneMatrix = (matrix: readonly (readonly number[])[]): number[][] => (
+  matrix.map((row) => [...row])
+);
+
+const assertSameMatrix = (
+  actual: readonly (readonly number[])[],
+  expected: readonly (readonly number[])[],
+  message: string,
+): void => {
+  if (actual.length !== expected.length) throw new Error(message);
+  for (let row = 0; row < actual.length; row += 1) {
+    if (actual[row].length !== expected[row].length) throw new Error(message);
+    for (let column = 0; column < actual[row].length; column += 1) {
+      if (Math.abs(actual[row][column] - expected[row][column]) > MATRIX_TOLERANCE) {
+        throw new Error(`${message} at [${row}][${column}]`);
+      }
+    }
+  }
+};
+
+const recordKey = (record: PairCompressionRecord): string => (
+  `${record.sourceContentKey}\u0000${record.targetContentKey}`
+);
+
+const setConsistentSize = (sizes: Map<string, number>, key: string, value: number, description: string): void => {
+  if (!isValidCompressionSize(value)) throw new Error(`${description} has an invalid compressed size`);
+  const previous = sizes.get(key);
+  if (previous !== undefined && previous !== value) {
+    throw new Error(`${description} has conflicting compressed sizes`);
+  }
+  sizes.set(key, value);
+};
+
+/** Reconstruct the complete compressed-size record set from cache hits and worker misses. */
+export const collectCompleteCompressionRecords = ({
+  algorithm,
+  contentKeys,
+  cachedSizes,
+  newSingles,
+  newOrderedPairs,
+}: CompleteCompressionRecordInput): CompleteCompressionRecords => {
+  if (!contentKeys.length) throw new Error("Compression records require at least one content key");
+
+  const allowedContentKeys = new Set(contentKeys);
+  const newSingleSizes = new Map<string, number>();
+  for (const record of newSingles) {
+    if (!allowedContentKeys.has(record.contentKey)) {
+      throw new Error(`Worker returned a single-object record outside this experiment: ${record.contentKey}`);
+    }
+    setConsistentSize(newSingleSizes, record.contentKey, record.compressedSize, `Single-object record ${record.contentKey}`);
+  }
+  const singles: SingleCompressionRecord[] = [];
+  for (const contentKey of [...new Set(contentKeys)]) {
+    const cachedSize = cachedSizes.get(createSingleCacheKey(algorithm, contentKey));
+    const newSize = newSingleSizes.get(contentKey);
+    if (cachedSize !== undefined && newSize !== undefined && cachedSize !== newSize) {
+      throw new Error(`Cache and worker disagree on the single-object size for ${contentKey}`);
+    }
+    const compressedSize = newSize ?? cachedSize;
+    if (!isValidCompressionSize(compressedSize ?? Number.NaN)) {
+      throw new Error(`Missing a valid single-object compressed size for ${contentKey}`);
+    }
+    singles.push({contentKey, compressedSize: compressedSize!});
+  }
+
+  const newPairSizes = new Map<string, number>();
+  for (const record of newOrderedPairs) {
+    if (!allowedContentKeys.has(record.sourceContentKey) || !allowedContentKeys.has(record.targetContentKey)) {
+      throw new Error("Worker returned an ordered-pair record outside this experiment");
+    }
+    setConsistentSize(
+      newPairSizes,
+      recordKey(record),
+      record.compressedSize,
+      `Ordered-pair record ${record.sourceContentKey} -> ${record.targetContentKey}`,
+    );
+  }
+  const orderedPairs: PairCompressionRecord[] = [];
+  const seenPairs = new Set<string>();
+  for (let source = 0; source < contentKeys.length; source += 1) {
+    for (let target = 0; target < contentKeys.length; target += 1) {
+      if (source === target) continue;
+      const sourceContentKey = contentKeys[source];
+      const targetContentKey = contentKeys[target];
+      const key = `${sourceContentKey}\u0000${targetContentKey}`;
+      if (seenPairs.has(key)) continue;
+      seenPairs.add(key);
+      const cachedSize = cachedSizes.get(createPairCacheKey(algorithm, sourceContentKey, targetContentKey));
+      const newSize = newPairSizes.get(key);
+      if (cachedSize !== undefined && newSize !== undefined && cachedSize !== newSize) {
+        throw new Error(`Cache and worker disagree on ${sourceContentKey} -> ${targetContentKey}`);
+      }
+      const compressedSize = newSize ?? cachedSize;
+      if (!isValidCompressionSize(compressedSize ?? Number.NaN)) {
+        throw new Error(`Missing a valid ordered-pair compressed size for ${sourceContentKey} -> ${targetContentKey}`);
+      }
+      orderedPairs.push({sourceContentKey, targetContentKey, compressedSize: compressedSize!});
+    }
+  }
+  return {singles, orderedPairs};
+};
+
+const assertSearchSummary = (tree: QTreeResponse): void => {
+  const {search} = tree;
+  const unsignedInteger = (value: number) => Number.isInteger(value) && value >= 0 && value <= 0xffffffff;
+  if (
+    !search.pipelineVersion
+    || !Number.isInteger(search.runCount)
+    || search.runCount < 1
+    || !unsignedInteger(search.baseSeed)
+    || !unsignedInteger(search.selectedSeed)
+    || ![search.selectedScore, search.scoreMinimum, search.scoreMean, search.scoreMaximum].every(Number.isFinite)
+    || search.scoreMinimum > search.scoreMean
+    || search.scoreMean > search.scoreMaximum
+    || Math.abs(search.selectedScore - search.scoreMaximum) > MATRIX_TOLERANCE
+    || !Number.isInteger(search.selectedTopologyCount)
+    || search.selectedTopologyCount < 1
+    || search.selectedTopologyCount > search.runCount
+    || !Number.isInteger(search.uniqueTopologyCount)
+    || search.uniqueTopologyCount < 1
+    || search.uniqueTopologyCount > search.runCount
+    || !Number.isFinite(search.selectedTopologySupport)
+    || Math.abs(search.selectedTopologySupport - (search.selectedTopologyCount / search.runCount)) > MATRIX_TOLERANCE
+    || search.supportKind !== "repeated-search-stability"
+  ) {
+    throw new Error("Quartet tree search metadata is inconsistent");
+  }
+};
+
+const buildExportedObjects = async (input: NCDInput): Promise<ExportedExperimentObject[]> => {
+  const kind = input.kind ?? "objects";
+  if (!input.objectMetadata || input.objectMetadata.length !== input.labels.length) {
+    throw new Error("Experiment object metadata must match the object labels");
+  }
+  if (input.contents.length !== input.labels.length) {
+    throw new Error("Experiment contents must match the object labels");
+  }
+
+  const objects: ExportedExperimentObject[] = [];
+  for (let index = 0; index < input.labels.length; index += 1) {
+    const metadata = input.objectMetadata[index];
+    if (metadata.id !== input.labels[index]) {
+      throw new Error(`Experiment metadata is out of order at object ${index}`);
+    }
+    if (!metadata.displayLabel.trim() || (
+      input.displayLabels
+      && metadata.displayLabel !== input.displayLabels[index]
+    )) {
+      throw new Error(`Experiment display metadata is inconsistent at object ${index}`);
+    }
+    if (kind === "distance-matrix") {
+      if (metadata.source.kind !== "imported-distance-matrix") {
+        throw new Error(`Imported matrix object ${metadata.id} has invalid source metadata`);
+      }
+      if (metadata.source.fileName !== input.sourceFileName) {
+        throw new Error(`Imported matrix source filename is inconsistent at object ${index}`);
+      }
+      objects.push({...metadata, index, data: null, contentKey: null});
+      continue;
+    }
+
+    const text = input.contents[index];
+    const encoded = new TextEncoder().encode(text);
+    const digest = await sha256(text);
+    objects.push({
+      ...metadata,
+      index,
+      contentKey: `${SHA256_PREFIX}${digest}`,
+      data: {
+        mediaType: "text/plain; charset=utf-8",
+        encoding: "utf-8",
+        utf8Bytes: encoded.byteLength,
+        sha256: digest,
+        text,
+      },
+    });
+  }
+  return objects;
+};
+
+const validateCompressionRecords = (
+  objects: readonly ExportedExperimentObject[],
+  directedMatrix: readonly (readonly number[])[],
+  records: CompleteCompressionRecords,
+): void => {
+  const singleSizes = new Map(records.singles.map((record) => [record.contentKey, record.compressedSize]));
+  const pairSizes = new Map(records.orderedPairs.map((record) => [recordKey(record), record.compressedSize]));
+  if (singleSizes.size !== records.singles.length || pairSizes.size !== records.orderedPairs.length) {
+    throw new Error("Compression records contain duplicate keys");
+  }
+
+  for (let source = 0; source < objects.length; source += 1) {
+    const sourceKey = objects[source].contentKey;
+    if (!sourceKey) throw new Error(`Object ${source} is missing its content key`);
+    const sizeX = singleSizes.get(sourceKey);
+    if (!isValidCompressionSize(sizeX ?? Number.NaN)) {
+      throw new Error(`Compression records omit C(x) for object ${source}`);
+    }
+    for (let target = 0; target < objects.length; target += 1) {
+      if (source === target) continue;
+      const targetKey = objects[target].contentKey;
+      if (!targetKey) throw new Error(`Object ${target} is missing its content key`);
+      const sizeY = singleSizes.get(targetKey);
+      const sizeXY = pairSizes.get(`${sourceKey}\u0000${targetKey}`);
+      if (!isValidCompressionSize(sizeY ?? Number.NaN) || !isValidCompressionSize(sizeXY ?? Number.NaN)) {
+        throw new Error(`Compression records omit C(x,y) for [${source}][${target}]`);
+      }
+      const expected = calculateNcd(sizeX!, sizeY!, sizeXY!);
+      if (Math.abs(expected - directedMatrix[source][target]) > MATRIX_TOLERANCE) {
+        throw new Error(`Compression records do not reproduce directed NCD [${source}][${target}]`);
+      }
+    }
+  }
+};
+
+const buildTree = (
+  tree: QTreeResponse,
+  objects: readonly ExportedExperimentObject[],
+): ClusteringExperimentExport["experiment"]["quartetTree"] => {
+  assertSearchSummary(tree);
+  extractTreeSplits(tree);
+  const objectById = new Map(objects.map((object) => [object.id, object]));
+  const nodeByIndex = new Map(tree.nodes.map((node) => [node.index, node]));
+  const leafIds = tree.nodes.filter((node) => node.connections.length === 1).map((node) => node.label);
+  if (leafIds.length !== objects.length || leafIds.some((id) => !objectById.has(id))) {
+    throw new Error("Quartet tree leaves do not match the experiment objects");
+  }
+
+  const nodes: ExportedTreeNode[] = tree.nodes.map((node) => {
+    const isLeaf = node.connections.length === 1;
+    const object = isLeaf ? objectById.get(node.label) : undefined;
+    return {
+      index: node.index,
+      kind: isLeaf ? "leaf" : "branch",
+      nativeLabel: isLeaf ? null : (node.label || null),
+      objectId: object?.id ?? null,
+      displayLabel: object?.displayLabel ?? null,
+      connections: [...node.connections],
+    };
+  });
+
+  const edgeKeys = new Set<string>();
+  const edges: ExportedTreeEdge[] = [];
+  for (const node of tree.nodes) {
+    for (const connection of node.connections) {
+      const edgeKey = getTreeEdgeKey(node.index, connection);
+      if (edgeKeys.has(edgeKey)) continue;
+      edgeKeys.add(edgeKey);
+      const support = tree.edgeSupport[edgeKey];
+      if (support !== undefined && (!Number.isFinite(support) || support < 0 || support > 1)) {
+        throw new Error(`Quartet tree has invalid support for edge ${edgeKey}`);
+      }
+      edges.push({
+        source: Math.min(node.index, connection),
+        target: Math.max(node.index, connection),
+        support: support ?? null,
+        supportKind: support === undefined ? null : tree.search.supportKind,
+      });
+    }
+  }
+  if (Object.keys(tree.edgeSupport).some((edgeKey) => !edgeKeys.has(edgeKey))) {
+    throw new Error("Quartet tree support references a missing edge");
+  }
+
+  const expectedBalancedSplit = getBalancedTreeSplit(tree, tree.edgeSupport);
+  if (JSON.stringify(expectedBalancedSplit) !== JSON.stringify(tree.balancedSplit)) {
+    throw new Error("Quartet tree balanced-split metadata is inconsistent");
+  }
+  const splitObjects = (indices: readonly number[]) => indices.map((index) => {
+    const node = nodeByIndex.get(index);
+    const object = node ? objectById.get(node.label) : undefined;
+    if (!object) throw new Error(`Balanced split references non-leaf node ${index}`);
+    return {index: object.index, id: object.id, displayLabel: object.displayLabel};
+  });
+  const balancedSplit: ExportedBalancedSplit = {
+    ...tree.balancedSplit,
+    leftLeafIndices: [...tree.balancedSplit.leftLeafIndices],
+    rightLeafIndices: [...tree.balancedSplit.rightLeafIndices],
+    leftObjects: splitObjects(tree.balancedSplit.leftLeafIndices),
+    rightObjects: splitObjects(tree.balancedSplit.rightLeafIndices),
+  };
+
+  return {
+    rooted: false,
+    nodes,
+    edges,
+    edgeSupport: {...tree.edgeSupport},
+    balancedSplit,
+    search: {...tree.search},
+  };
+};
+
+type ExportedInput = ClusteringExperimentExport["experiment"]["input"];
+type ExportedDistanceAnalysis = ClusteringExperimentExport["experiment"]["distanceAnalysis"];
+type ExportedQuartetTree = ClusteringExperimentExport["experiment"]["quartetTree"];
+
+/**
+ * Build the compact integrity material without copying raw input text.
+ * Object SHA-256 values bind the omitted text bytes to this manifest.
+ */
+export const getClusteringExperimentIntegrityMaterial = (
+  input: ExportedInput,
+  distanceAnalysis: ExportedDistanceAnalysis,
+  quartetTree: ExportedQuartetTree,
+): string => JSON.stringify({
+  inputManifest: {
+    kind: input.kind,
+    sourceFileName: input.sourceFileName,
+    objectCount: input.objectCount,
+    objects: input.objects.map(({data, ...object}) => ({
+      ...object,
+      data: data === null ? null : {
+        mediaType: data.mediaType,
+        encoding: data.encoding,
+        utf8Bytes: data.utf8Bytes,
+        sha256: data.sha256,
+      },
+    })),
+  },
+  distanceAnalysis,
+  quartetTree,
+});
+
+export const buildClusteringExperimentExport = async ({
+  input,
+  matrix,
+  compressionRecords,
+  tree,
+  timing,
+  exportedAt = new Date().toISOString(),
+}: BuildClusteringExperimentInput): Promise<ClusteringExperimentExport> => {
+  assertIsoTimestamp(timing.startedAt, "Experiment start time");
+  assertIsoTimestamp(timing.completedAt, "Experiment completion time");
+  assertIsoTimestamp(exportedAt, "Export time");
+  if (Date.parse(timing.completedAt) < Date.parse(timing.startedAt)) {
+    throw new Error("Experiment completion time precedes its start time");
+  }
+  if (matrix.labels.length !== input.labels.length || matrix.labels.some((label, index) => label !== input.labels[index])) {
+    throw new Error("Matrix labels do not match the experiment input order");
+  }
+  const matrixError = validateMatrix(matrix.labels, matrix.ncdMatrix);
+  if (matrixError) throw new Error(`Cannot export an invalid NCD matrix: ${matrixError}`);
+
+  const kind = input.kind ?? "objects";
+  if (kind === "objects" && input.sourceFileName !== undefined) {
+    throw new Error("Object experiments must not claim an imported matrix source file");
+  }
+  if (kind === "distance-matrix" && !input.sourceFileName?.trim()) {
+    throw new Error("Imported matrix experiments require the source filename");
+  }
+  const objects = await buildExportedObjects(input);
+  const directedNcdMatrix = matrix.directedNcdMatrix ? cloneMatrix(matrix.directedNcdMatrix) : null;
+  if (kind === "objects") {
+    if (!directedNcdMatrix || matrix.provenance.source !== "computed" || !compressionRecords) {
+      throw new Error("Computed experiments require directed NCD and complete compression records");
+    }
+    assertSameMatrix(
+      reduceDirectedMatrix(directedNcdMatrix),
+      matrix.ncdMatrix,
+      "Reflected-minimum matrix does not match the directed matrix",
+    );
+    validateCompressionRecords(objects, directedNcdMatrix, compressionRecords);
+  } else if (directedNcdMatrix || compressionRecords || matrix.provenance.source !== "imported") {
+    throw new Error("Imported matrix experiments must not claim computed compression records");
+  }
+
+  const objectOrder = objects.map(({index, id, displayLabel}) => ({index, id, displayLabel}));
+  const distanceAnalysis = {
+    objectOrder,
+    directedNcdMatrix,
+    reflectedMinimumNcdMatrix: cloneMatrix(matrix.ncdMatrix),
+    compression: {
+      provenance: {...matrix.provenance},
+      records: compressionRecords ? {
+        singles: compressionRecords.singles.map((record) => ({...record})),
+        orderedPairs: compressionRecords.orderedPairs.map((record) => ({...record})),
+      } : null,
+    },
+  };
+  const quartetTree = buildTree(tree, objects);
+  const exportedInput = {
+    kind,
+    sourceFileName: input.sourceFileName ?? null,
+    objectCount: objects.length,
+    objects,
+  };
+  const resultDigest = await sha256(
+    getClusteringExperimentIntegrityMaterial(exportedInput, distanceAnalysis, quartetTree),
+  );
+
+  return {
+    format: CLUSTERING_EXPERIMENT_FORMAT,
+    schemaVersion: CLUSTERING_EXPERIMENT_SCHEMA_VERSION,
+    schema: CLUSTERING_EXPERIMENT_SCHEMA_URL,
+    exportedAt,
+    experiment: {
+      id: `${SHA256_PREFIX}${resultDigest}`,
+      timing: {...timing},
+      input: exportedInput,
+      distanceAnalysis,
+      quartetTree,
+    },
+    integrity: {
+      algorithm: "SHA-256",
+      scope: "input-manifest + distance-analysis + quartet-tree",
+      canonicalization: "complearn-export-integrity-v1",
+      sha256: resultDigest,
+    },
+  };
+};
+
+export const serializeClusteringExperimentExport = (value: ClusteringExperimentExport): string => (
+  JSON.stringify(value)
+);
+
+export const getClusteringExperimentFilename = (exportedAt: string): string => {
+  assertIsoTimestamp(exportedAt, "Export time");
+  return `complearn-clustering-${exportedAt.replace(/[-:]/gu, "").replace(/\.\d{3}Z$/u, "Z")}.json`;
+};

--- a/ncd-calculator/src/types/experiment.ts
+++ b/ncd-calculator/src/types/experiment.ts
@@ -1,0 +1,131 @@
+import type {GenBankSequenceProvenance} from "@/services/genbankSequencePipeline";
+import type {UdhrLanguageRecord} from "@/functions/udhr";
+import type {AstronomyExampleProvenance} from "@/services/astronomyExample";
+import type {
+  CompressionProvenance,
+  PairCompressionRecord,
+  SingleCompressionRecord,
+} from "@/types/compression";
+import type {QSearchBalancedSplit, QSearchSummary} from "@/types/qsearch";
+
+export type ExperimentObjectSource =
+  | {
+      readonly kind: "genbank";
+      readonly provenance: GenBankSequenceProvenance;
+    }
+  | {
+      readonly kind: "udhr";
+      readonly corpus: {
+        readonly schemaVersion: number;
+        readonly corpusVersion: string;
+        readonly assetBasePath: string;
+        readonly source: Readonly<Record<string, string>>;
+        readonly summary: Readonly<Record<string, number>>;
+      };
+      readonly record: UdhrLanguageRecord;
+    }
+  | {
+      readonly kind: "built-in-example";
+      readonly exampleId: string;
+    }
+  | {
+      readonly kind: "astronomy";
+      readonly provenance: AstronomyExampleProvenance;
+    }
+  | {
+      readonly kind: "local-file";
+      readonly fileName: string;
+    }
+  | {
+      readonly kind: "imported-distance-matrix";
+      readonly fileName: string;
+    };
+
+export interface ExperimentInputObjectMetadata {
+  readonly id: string;
+  readonly displayLabel: string;
+  readonly source: ExperimentObjectSource;
+}
+
+export interface CompleteCompressionRecords {
+  readonly singles: readonly SingleCompressionRecord[];
+  readonly orderedPairs: readonly PairCompressionRecord[];
+}
+
+export interface ClusteringExperimentTiming {
+  readonly startedAt: string;
+  readonly completedAt: string;
+}
+
+export interface ExportedExperimentObject extends ExperimentInputObjectMetadata {
+  readonly index: number;
+  readonly data: {
+    readonly mediaType: "text/plain; charset=utf-8";
+    readonly encoding: "utf-8";
+    readonly utf8Bytes: number;
+    readonly sha256: string;
+    readonly text: string;
+  } | null;
+  readonly contentKey: string | null;
+}
+
+export interface ExportedTreeNode {
+  readonly index: number;
+  readonly kind: "leaf" | "branch";
+  readonly nativeLabel: string | null;
+  readonly objectId: string | null;
+  readonly displayLabel: string | null;
+  readonly connections: readonly number[];
+}
+
+export interface ExportedTreeEdge {
+  readonly source: number;
+  readonly target: number;
+  readonly support: number | null;
+  readonly supportKind: "repeated-search-stability" | null;
+}
+
+export interface ExportedBalancedSplit extends QSearchBalancedSplit {
+  readonly leftObjects: readonly Pick<ExportedExperimentObject, "index" | "id" | "displayLabel">[];
+  readonly rightObjects: readonly Pick<ExportedExperimentObject, "index" | "id" | "displayLabel">[];
+}
+
+export interface ClusteringExperimentExport {
+  readonly format: "complearn-clustering-experiment";
+  readonly schemaVersion: 1;
+  readonly schema: string;
+  readonly exportedAt: string;
+  readonly experiment: {
+    readonly id: string;
+    readonly timing: ClusteringExperimentTiming;
+    readonly input: {
+      readonly kind: "objects" | "distance-matrix";
+      readonly sourceFileName: string | null;
+      readonly objectCount: number;
+      readonly objects: readonly ExportedExperimentObject[];
+    };
+    readonly distanceAnalysis: {
+      readonly objectOrder: readonly Pick<ExportedExperimentObject, "index" | "id" | "displayLabel">[];
+      readonly directedNcdMatrix: readonly (readonly number[])[] | null;
+      readonly reflectedMinimumNcdMatrix: readonly (readonly number[])[];
+      readonly compression: {
+        readonly provenance: CompressionProvenance;
+        readonly records: CompleteCompressionRecords | null;
+      };
+    };
+    readonly quartetTree: {
+      readonly rooted: false;
+      readonly nodes: readonly ExportedTreeNode[];
+      readonly edges: readonly ExportedTreeEdge[];
+      readonly edgeSupport: Readonly<Record<string, number>>;
+      readonly balancedSplit: ExportedBalancedSplit;
+      readonly search: QSearchSummary;
+    };
+  };
+  readonly integrity: {
+    readonly algorithm: "SHA-256";
+    readonly scope: "input-manifest + distance-analysis + quartet-tree";
+    readonly canonicalization: "complearn-export-integrity-v1";
+    readonly sha256: string;
+  };
+}

--- a/ncd-calculator/src/types/ncd.d.ts
+++ b/ncd-calculator/src/types/ncd.d.ts
@@ -3,6 +3,7 @@ import type {
     PairCompressionRecord,
     SingleCompressionRecord,
 } from "./compression";
+import type {ExperimentInputObjectMetadata} from "./experiment";
 
 export interface CompressionStats {
     processedPairs: number;
@@ -21,6 +22,10 @@ export interface NCDInput {
     /** Human-readable labels in the same order as `labels`. */
     displayLabels?: string[];
     kind?: 'objects' | 'distance-matrix';
+    /** Source and presentation metadata in the same order as `labels`. */
+    objectMetadata?: ExperimentInputObjectMetadata[];
+    /** Original filename when `kind` is an imported distance matrix. */
+    sourceFileName?: string;
     cachedSizes?: Map<string, number>;
     contentKeys?: string[];
 }


### PR DESCRIPTION
## Summary

Add a result-scoped JSON download for a completed clustering experiment. The export is designed as a reproducible research artifact rather than a tree-only rendering: it captures the exact inputs, source provenance, compression measurements, directed and symmetrized distances, selected QSearch topology, repeated-search support, search summary, timing, and integrity metadata needed to inspect or reproduce the result.

The existing DOT action remains available inside the tree view for topology interchange. The new **Download JSON** action appears beside the completed result summary and is disabled until the clustering result is complete and internally consistent.

## Export contract

The versioned `complearn-clustering-experiment` document includes:

- exact UTF-8 input text, byte length, SHA-256 digest, stable content key, ID, and display label for every object;
- typed provenance for verified GenBank records, bundled UDHR records, bundled RXTE astronomy records, local files, built-in examples, and imported distance matrices;
- compressor identity and protocol metadata;
- every single-object compressed size and every ordered-pair compressed size, including measurements reconstructed from valid cache hits;
- the full order-dependent NCD matrix and the reflected-minimum matrix used by QSearch;
- the selected unrooted tree as stable node and edge records, with leaf-to-object references and repeated-search edge stability;
- the balanced display split, QSearch seed, best score, search count, topology counts, selected-topology frequency, duration, and protocol version;
- a deterministic experiment ID and SHA-256 integrity digest.

The public JSON Schema is stored at `public/schemas/clustering-experiment-v1.schema.json`. A build-time verifier prevents the checked-in schema and implementation constants from drifting apart.

## Reliability and scientific behavior

Export generation fails fast rather than emitting a partial or misleading artifact. It verifies:

- object labels, metadata order, IDs, and display labels;
- source-type claims and required provenance;
- directed and reflected matrix dimensions and finite values;
- each directed NCD value by recomputing it from `C(x)`, `C(y)`, and `C(x,y)`;
- completeness and consistency of cached and newly computed compression records;
- tree connectivity, acyclicity, reciprocal adjacency, leaf coverage, and edge support values;
- agreement between the balanced split and the exported objects;
- consistency of the multi-start search summary.

The integrity hash covers a canonical compact manifest of input identities and provenance, distance analysis, and tree analysis. It is an accidental-corruption and identity check, not a cryptographic signature or statement of scientific validity.

## Scalability and privacy

JSON is serialized without pretty-printing to reduce transient memory and download size. Input hashes are computed sequentially, and the integrity manifest references content digests instead of copying raw input text a second time. Compression cache hits and worker misses are normalized into the same complete ordered record set.

Exports intentionally contain the complete raw comparison inputs so an experiment can be reproduced. Users should therefore treat exports of private local files as sensitive data.

Imported distance-matrix experiments retain the original filename and matrix provenance. Because raw objects and compression measurements are not available in that workflow, the schema and export distinguish imported matrices from object-based NCD experiments rather than asserting unsupported provenance.

## Documentation

- Add `docs/CLUSTERING_EXPERIMENT_EXPORT.md` with the field model, integrity semantics, validation rules, scalability notes, privacy warning, and compatibility policy.
- Link the export documentation from the repository and calculator READMEs.
- Add the schema verifier to the production build pipeline.

## Validation

- Full frontend suite before rebasing onto the merged astronomy work: **33 files, 229 tests passed**.
- Post-rebase export/workbench/astronomy suite: **3 files, 20 tests passed**.
- Production build passed, including Graphviz, compression-worker, UDHR corpus, astronomy corpus, export-schema, and final bundle verification.
- Focused browser exercise completed from example selection through QSearch completion and JSON-download activation; no application or export error was reported.
- `git diff --check origin/main...HEAD` passed.

Existing non-blocking Vite notices remain for a deprecated worker plugin configuration, browser-externalized ZSTD imports, and large generated chunks; this change does not introduce those warnings.
