### PR TITLE
Add explainable cluster report

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -37,6 +37,7 @@ ncd-calculator/
 │   │   ├── QSearch.tsx             # Main NCD calculator page (orchestrates everything)
 │   │   ├── ListEditor.tsx          # Input management (FASTA, files, languages)
 │   │   ├── InputHolder.tsx         # Selected items display
+│   │   ├── ClusterReport.tsx        # Explainable groups, pairs, and research summary
 │   │   ├── MatrixTable.tsx         # NCD matrix display
 │   │   ├── KGridVisualization.tsx  # 2D grid similarity visualization
 │   │   ├── KGridDualOptimization.tsx # Dual-run grid optimization
@@ -69,6 +70,7 @@ ncd-calculator/
 │   │   ├── qsearchWorker.ts        # QSearch tree algorithm worker
 │   │   └── kgridWorker.ts          # Grid optimization worker
 │   ├── services/
+│   │   ├── ClusterAnalysis.ts      # Deterministic average-linkage analysis
 │   │   ├── CompressionService.ts   # Compression worker orchestration (singleton)
 │   │   ├── CompressionProtocol.ts  # Versioned compressor and pair policy
 │   │   ├── QSearchProtocol.ts      # Seed schedule, canonical splits, support
@@ -185,6 +187,8 @@ Updated 2026-08-06 (Asia/Ho_Chi_Minh).
 
 The calculator route begins directly at the source controls and comparison set. `ListEditor.tsx` owns input selection and computation readiness; the source components handle GenBank, UDHR, and local-file acquisition; `InputHolder.tsx` provides a compact accessible object inventory. **Try example data** remains available beside the source selector, while the primary **Show Similarity** action closes the workflow at the bottom right. Long source corpora, including the UDHR language list, scroll within a keyboard-focusable work area instead of extending the page.
 
+Completed computations open on `ClusterReport.tsx`. Its pure `ClusterAnalysis.ts` service applies deterministic average-linkage clustering to the validated symmetric NCD matrix, evaluates candidate group counts with mean silhouette, and derives group membership, nearest pairs, nearest neighbors, relative isolation, and within/between summaries. Users can cut the same dendrogram at another group count without recomputing compression. QSearch remains a separate unrooted topology view; its selected-topology recurrence is shown only in the report's research section and is labeled optimization repeatability rather than scientific confidence. The complete method and scenario contract is documented in `ncd-calculator/docs/EXPLAINABLE_CLUSTER_REPORT.md`.
+
 `Workbench.css` extends the landing-page visual system across input preparation, progress, and result interpretation. The production GUI follows `ncd-calculator/docs/END_USER_UI_POLICY.md`: it shows actionable controls, meaningful progress, canonical object names, and scientific results, while seeds, internal identifiers, protocol versions, worker rates, iteration counts, objective values, cache state, and optimizer diagnostics remain in exports, logs, tests, or technical documentation. `src/__test__/workbench.test.tsx` verifies the example-set invariants, minimum-set readiness message, empty state, and accessible item removal; visualization tests prevent internal QSearch diagnostics from returning to the live tree.
 
 ## UDHR Corpus Pipeline
@@ -220,6 +224,7 @@ npx vitest --run --exclude='**/webworker*'
 - **Web Workers** — All heavy computation (compression, QSearch, grid optimization) runs in dedicated web workers to keep the UI responsive.
 - **Singleton Services** — `CompressionService` uses a singleton pattern with factory injection for testability.
 - **Protocol-versioned caching** — Compression results use SHA-256 content identities and ordered source-target cache keys that include the pipeline and compressor revision. Stale schemas are removed rather than reused.
+- **Deterministic explainable clustering** — Average-linkage grouping uses stable-identifier tie breaks, silhouette-based suggestions, and explicit weak-separation language.
 - **Seeded multi-start QSearch** — A bounded deterministic schedule explores multiple randomized starts. Canonical split counting reports optimization stability.
 - **Pinned QSearch WASM** — `make wasm-calculator` builds the checked-in module with Emscripten 3.1.74. CI verifies that regeneration is clean.
 

--- a/ncd-calculator/docs/END_USER_UI_POLICY.md
+++ b/ncd-calculator/docs/END_USER_UI_POLICY.md
@@ -1,11 +1,11 @@
 # End-user interface policy
 
-Updated 2026-08-06 (Asia/Ho_Chi_Minh).
+Updated 2026-08-09 (Asia/Ho_Chi_Minh).
 
 The workbench GUI is a research product for people comparing objects, not a live debugger for its implementation. Every visible element should help a user prepare inputs, start or stop an action, understand progress, inspect a scientific result, recover from an error, or export their work.
 
-The primary interface may show canonical object names, input counts, meaningful loading or completion states, the NCD matrix, the inferred tree, the K-grid arrangement, and controls needed to inspect those results. Scientific caveats belong in the method and corpus documentation when they are not necessary to interpret the immediate view.
+The primary interface may show canonical object names, input counts, meaningful loading or completion states, the NCD matrix, deterministic group memberships, nearest-pair and relative-isolation summaries, the inferred tree, the K-grid arrangement, and controls needed to inspect those results. A separation summary must include the limitation needed to interpret it; longer method and corpus caveats belong in technical documentation.
 
-The GUI must not expose internal object identifiers, random seeds, protocol or cache versions, worker throughput, iteration counters, objective-function values, raw topology-search counts, debug messages, or implementation-oriented status bars. These values remain available through typed computation results, explicit research exports, browser or worker logs, automated tests, and technical documentation. An error shown to a user should describe what failed and what they can do next; internal stack traces and transport details stay in logs.
+The GUI must not expose internal object identifiers, random seeds, protocol or cache versions, worker throughput, iteration counters, objective-function values, debug messages, or implementation-oriented status bars. A research section may show the selected topology's aggregate recurrence across the bounded search schedule only when it is labeled optimization repeatability and explicitly distinguished from bootstrap support or scientific confidence. Seeds, per-run scores, internal topology identifiers, and edge-level search diagnostics remain available through typed computation results, explicit research exports, browser or worker logs, automated tests, and technical documentation. An error shown to a user should describe what failed and what they can do next; internal stack traces and transport details stay in logs.
 
 New interface work should apply this test before adding text or controls: if the information is useful mainly for diagnosing the implementation and does not help the user make a decision about their data or result, it does not belong in the production GUI.

--- a/ncd-calculator/docs/EXPLAINABLE_CLUSTER_REPORT.md
+++ b/ncd-calculator/docs/EXPLAINABLE_CLUSTER_REPORT.md
@@ -1,0 +1,62 @@
+# Explainable cluster report
+
+Updated 2026-08-09 (Asia/Ho_Chi_Minh).
+
+## Purpose
+
+The cluster report is the default result view after an NCD computation. It converts the symmetric NCD matrix into explicit, inspectable group memberships without replacing the matrix or the QSearch topology. The report is intended to answer the first questions a non-specialist asks—what is close, what groups are suggested, and whether the partition is clear—while retaining the definitions and limitations a researcher needs to audit the summary.
+
+The distance matrix remains the measurement. Average-linkage groups, silhouette values, the most isolated object, the quartet tree, and the K-grid are derived interpretations of that matrix. The interface therefore uses language such as “suggested,” “relative,” and “exploratory” rather than presenting a partition as ground truth.
+
+## Deterministic grouping contract
+
+`src/services/ClusterAnalysis.ts` validates the stable object identifiers and complete symmetric distance matrix before producing any summary. It then constructs an agglomerative dendrogram with average linkage. If clusters `A` and `B` merge, their distance to another cluster `C` is updated as:
+
+```text
+d(A ∪ B, C) = (|A| d(A, C) + |B| d(B, C)) / (|A| + |B|)
+```
+
+Equal merge distances are resolved through lexicographically sorted stable object identifiers. Reordering matrix rows and columns therefore preserves the semantic partition. Display labels are presentation only and do not control a tie.
+
+The suggested cluster count maximizes mean silhouette over `k = 2, ..., min(8, n - 1)`. A singleton receives silhouette zero. Silhouette values equal within numerical tolerance prefer the smaller cluster count. Users may inspect any partition from 2 through `n - 1` groups; changing this control cuts the same deterministic dendrogram and does not recompute NCD.
+
+The interface gives silhouette a deliberately modest qualitative description:
+
+| Mean silhouette | Interface description | Interpretation |
+| ---: | --- | --- |
+| `>= 0.50` | Strong separation | Between-group distances are substantially larger than within-group distances in this matrix. |
+| `>= 0.25` and `< 0.50` | Moderate separation | Some structure is present, but overlap remains possible. |
+| `< 0.25` | Weak separation | A partition can be constructed, but it should be treated as exploratory. |
+
+These bands are descriptive interface guidance, not confidence intervals, universal NCD thresholds, or evidence that a real-world class exists.
+
+## Evidence shown
+
+The primary report presents the group memberships, closest pair, five closest pairs, mean within-group distance, input provenance, and the object with the highest mean distance to all other objects. “Most isolated” is a relative matrix summary; the application does not call the object an anomaly or assign a statistical outlier probability.
+
+The expandable research section contains every object's nearest neighbor, candidate silhouettes, selected within-group and between-group means, and the selected QSearch topology's recurrence across deterministic restarts. That QSearch percentage is explicitly described as optimization repeatability. It is not bootstrap support, a posterior probability, or confidence in the average-linkage groups. Random seeds, objective values, protocol identifiers, and internal node identifiers remain outside the primary GUI.
+
+The existing clustering experiment JSON remains the reproducibility record. It contains the exact object order, matrix, compressor provenance, and QSearch result needed to regenerate the default report. A manually selected cluster count is presentation state and is not currently added to schema version 1 of the experiment export.
+
+## Scenario coverage
+
+The implementation is exercised against scenarios chosen to produce materially different reports:
+
+| Scenario | Expected report behavior |
+| --- | --- |
+| Two compact pairs | Suggest two groups, strong separation, and rank the closest pair correctly. |
+| Moderately separated pairs | Keep the same semantic groups while using the moderate-overlap explanation. |
+| Uniform equal distances | Produce a deterministic partition, zero silhouette, and explicit exploratory language. |
+| One distant object | Identify the object as most isolated without declaring a ground-truth anomaly. |
+| Three compact pairs | Suggest three groups and allow a manual two-group cut. |
+| Permuted matrix order | Preserve semantic group membership and silhouette. |
+| Imported matrix | Show imported provenance without inventing a compressor. |
+| Invalid asymmetric matrix | Fail before rendering a plausible report. |
+
+`src/__test__/clusterAnalysis.test.ts` verifies the numerical and deterministic contract. `src/__test__/clusterReport.test.tsx` verifies the plain-language, research, imported-provenance, and manual-selection states. `src/__test__/kGridVisualizationLifecycle.test.tsx` verifies that the report is the default result and that returning to it stops optional K-grid work.
+
+## Limits and future work
+
+Average linkage is one interpretation of NCD, not part of the NCD definition or the QSearch objective. Silhouette can favor a convenient partition even when the underlying objects lack scientifically meaningful classes. Input representation and compressor behavior remain experimental decisions. A future robustness mode should compare matrices and partitions across compatible compressors, recording disagreement rather than hiding it.
+
+The current dendrogram implementation uses `O(n²)` distance storage and `O(n³)` worst-case merge selection. This is appropriate for the browser workbench's current comparison sizes and remains small relative to pairwise compression and QSearch. A future large-study backend should use a specialized clustering implementation and preserve this tie-breaking and reporting contract.

--- a/ncd-calculator/docs/NCD_QSEARCH_REPRODUCIBILITY.md
+++ b/ncd-calculator/docs/NCD_QSEARCH_REPRODUCIBILITY.md
@@ -70,7 +70,7 @@ It also records the selected topology frequency, number of distinct topologies, 
 
 The result also identifies the internal edge with the most even number of leaves on its two sides. This "most balanced split" is a deterministic display summary. Search stability and canonical node-index ordering break ties. It does not change the NCD matrix, select a different QSearch topology, infer an evolutionary root, or assert that either side is a known scientific class. Leaf indices rather than display labels define the split, so repeated human-readable names cannot make distinct inputs collide.
 
-These diagnostics remain in the typed QSearch result and are included as comments and edge metadata when the user explicitly exports DOT. They are intentionally absent from the live tree: seed values, optimizer scores, run counts, protocol identifiers, and heuristic split summaries are reproducibility metadata rather than primary end-user results. The live view presents the inferred unrooted topology and language names only.
+These diagnostics remain in the typed QSearch result and are included as comments and edge metadata when the user explicitly exports DOT. They are intentionally absent from the live tree: seed values, optimizer scores, protocol identifiers, edge-level percentages, and heuristic split summaries are reproducibility metadata rather than primary tree labels. The explainable cluster report may state how often the selected complete topology recurred across the bounded deterministic schedule, together with the run count and an explicit warning that this is optimization repeatability rather than scientific confidence. The live tree itself presents the inferred unrooted topology and object names only.
 
 ## Fail-fast boundaries
 

--- a/ncd-calculator/src/__test__/clusterAnalysis.test.ts
+++ b/ncd-calculator/src/__test__/clusterAnalysis.test.ts
@@ -1,0 +1,146 @@
+import {describe, expect, test} from "vitest";
+import {buildClusterAnalysis} from "@/services/ClusterAnalysis";
+
+const STRONG_MATRIX = [
+    [0, 0.10, 0.90, 0.88],
+    [0.10, 0, 0.85, 0.90],
+    [0.90, 0.85, 0, 0.12],
+    [0.88, 0.90, 0.12, 0],
+];
+
+const UNIFORM_MATRIX = [
+    [0, 0.5, 0.5, 0.5],
+    [0.5, 0, 0.5, 0.5],
+    [0.5, 0.5, 0, 0.5],
+    [0.5, 0.5, 0.5, 0],
+];
+
+const THREE_GROUP_MATRIX = [
+    [0, 0.08, 0.82, 0.84, 0.88, 0.86],
+    [0.08, 0, 0.80, 0.83, 0.87, 0.89],
+    [0.82, 0.80, 0, 0.10, 0.81, 0.85],
+    [0.84, 0.83, 0.10, 0, 0.84, 0.82],
+    [0.88, 0.87, 0.81, 0.84, 0, 0.09],
+    [0.86, 0.89, 0.85, 0.82, 0.09, 0],
+];
+
+const analyze = (matrix = STRONG_MATRIX, clusterCount?: number) => buildClusterAnalysis({
+    objectIds: ["a", "b", "c", "d"],
+    displayLabels: ["Alpha", "Beta", "Gamma", "Delta"],
+    ncdMatrix: matrix,
+    clusterCount,
+});
+
+const semanticGroups = (groups: readonly {memberIds: readonly string[]}[]): string[] => (
+    groups.map(({memberIds}) => [...memberIds].sort().join("+")).sort()
+);
+
+describe("explainable cluster analysis", () => {
+    test("recovers two strongly separated pairs and ranks direct evidence", () => {
+        const result = analyze();
+
+        expect(result.suggestedClusterCount).toBe(2);
+        expect(result.selectedClusterCount).toBe(2);
+        expect(result.separation).toBe("strong");
+        expect(result.silhouette).toBeGreaterThan(0.8);
+        expect(semanticGroups(result.groups)).toEqual(["a+b", "c+d"]);
+        expect(result.closestPairs[0]).toMatchObject({
+            firstId: "a",
+            secondId: "b",
+            distance: 0.10,
+        });
+        expect(result.nearestNeighbors.find(({objectId}) => objectId === "d")).toMatchObject({
+            neighborId: "c",
+            distance: 0.12,
+        });
+        expect(result.meanWithinDistance).toBeCloseTo(0.11);
+        expect(result.meanBetweenDistance).toBeCloseTo(0.8825);
+    });
+
+    test("reports overlapping equal-distance data as weak and deterministic", () => {
+        const result = analyze(UNIFORM_MATRIX);
+
+        expect(result.suggestedClusterCount).toBe(2);
+        expect(result.silhouette).toBe(0);
+        expect(result.separation).toBe("weak");
+        expect(semanticGroups(result.groups)).toEqual(["a+b+c", "d"]);
+        expect(result.closestPairs[0]).toMatchObject({firstId: "a", secondId: "b"});
+    });
+
+    test("distinguishes moderate separation from both strong and ambiguous cases", () => {
+        const result = analyze([
+            [0, 0.30, 0.50, 0.55],
+            [0.30, 0, 0.54, 0.51],
+            [0.50, 0.54, 0, 0.30],
+            [0.55, 0.51, 0.30, 0],
+        ]);
+
+        expect(result.suggestedClusterCount).toBe(2);
+        expect(result.separation).toBe("moderate");
+        expect(result.silhouette).toBeGreaterThanOrEqual(0.25);
+        expect(result.silhouette).toBeLessThan(0.5);
+        expect(semanticGroups(result.groups)).toEqual(["a+b", "c+d"]);
+    });
+
+    test("identifies the most isolated object without declaring it a ground-truth outlier", () => {
+        const result = buildClusterAnalysis({
+            objectIds: ["a", "b", "c", "d", "e"],
+            displayLabels: ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+            ncdMatrix: [
+                [0, 0.10, 0.30, 0.34, 0.91],
+                [0.10, 0, 0.33, 0.31, 0.90],
+                [0.30, 0.33, 0, 0.12, 0.89],
+                [0.34, 0.31, 0.12, 0, 0.92],
+                [0.91, 0.90, 0.89, 0.92, 0],
+            ],
+        });
+
+        expect(result.mostIsolatedObject).toMatchObject({
+            objectId: "e",
+            objectLabel: "Epsilon",
+        });
+        expect(result.mostIsolatedObject.meanDistance).toBeCloseTo(0.905);
+    });
+
+    test("suggests three groups when three compact pairs are present and supports a manual cut", () => {
+        const input = {
+            objectIds: ["a", "b", "c", "d", "e", "f"],
+            displayLabels: ["A", "B", "C", "D", "E", "F"],
+            ncdMatrix: THREE_GROUP_MATRIX,
+        } as const;
+        const suggested = buildClusterAnalysis(input);
+        const manual = buildClusterAnalysis({...input, clusterCount: 2});
+
+        expect(suggested.suggestedClusterCount).toBe(3);
+        expect(semanticGroups(suggested.groups)).toEqual(["a+b", "c+d", "e+f"]);
+        expect(manual.selection).toBe("manual");
+        expect(manual.selectedClusterCount).toBe(2);
+        expect(manual.groups).toHaveLength(2);
+    });
+
+    test("preserves semantic groups when matrix order changes", () => {
+        const original = analyze();
+        const permutation = [3, 1, 0, 2];
+        const ids = ["a", "b", "c", "d"];
+        const labels = ["Alpha", "Beta", "Gamma", "Delta"];
+        const reordered = buildClusterAnalysis({
+            objectIds: permutation.map((index) => ids[index]),
+            displayLabels: permutation.map((index) => labels[index]),
+            ncdMatrix: permutation.map((row) => permutation.map((column) => STRONG_MATRIX[row][column])),
+        });
+
+        expect(reordered.suggestedClusterCount).toBe(original.suggestedClusterCount);
+        expect(reordered.silhouette).toBeCloseTo(original.silhouette);
+        expect(semanticGroups(reordered.groups)).toEqual(semanticGroups(original.groups));
+    });
+
+    test("fails fast on an asymmetric matrix and an invalid manual group count", () => {
+        expect(() => analyze([
+            [0, 0.1, 0.8, 0.8],
+            [0.2, 0, 0.8, 0.8],
+            [0.8, 0.8, 0, 0.1],
+            [0.8, 0.8, 0.1, 0],
+        ])).toThrow(/Matrix must be symmetric/);
+        expect(() => analyze(STRONG_MATRIX, 4)).toThrow(/between 2 and 3/);
+    });
+});

--- a/ncd-calculator/src/__test__/clusterReport.test.tsx
+++ b/ncd-calculator/src/__test__/clusterReport.test.tsx
@@ -1,0 +1,158 @@
+import {fireEvent, render, screen, within} from "@testing-library/react";
+import {describe, expect, test} from "vitest";
+import {ClusterReport} from "@/components/ClusterReport";
+import type {NCDMatrixResponse} from "@/types/ncd";
+import type {QTreeResponse} from "@/types/qsearch";
+
+const PROVENANCE = {
+    source: "computed",
+    algorithm: "lzma",
+    compressorRevision: "test",
+    pipelineVersion: "ncd-pipeline-v3",
+    cacheSchemaVersion: 3,
+    directedMatrixForm: "ordered",
+    matrixReduction: "reflected-minimum",
+    pairSeparator: "\n###\n",
+} as const;
+
+const STRONG_RESPONSE: NCDMatrixResponse = {
+    labels: ["a", "b", "c", "d"],
+    ncdMatrix: [
+        [0, 0.10, 0.90, 0.88],
+        [0.10, 0, 0.85, 0.90],
+        [0.90, 0.85, 0, 0.12],
+        [0.88, 0.90, 0.12, 0],
+    ],
+    provenance: PROVENANCE,
+};
+
+const WEAK_RESPONSE: NCDMatrixResponse = {
+    ...STRONG_RESPONSE,
+    ncdMatrix: [
+        [0, 0.5, 0.5, 0.5],
+        [0.5, 0, 0.5, 0.5],
+        [0.5, 0.5, 0, 0.5],
+        [0.5, 0.5, 0.5, 0],
+    ],
+};
+
+const THREE_GROUP_RESPONSE: NCDMatrixResponse = {
+    labels: ["a", "b", "c", "d", "e", "f"],
+    ncdMatrix: [
+        [0, 0.08, 0.82, 0.84, 0.88, 0.86],
+        [0.08, 0, 0.80, 0.83, 0.87, 0.89],
+        [0.82, 0.80, 0, 0.10, 0.81, 0.85],
+        [0.84, 0.83, 0.10, 0, 0.84, 0.82],
+        [0.88, 0.87, 0.81, 0.84, 0, 0.09],
+        [0.86, 0.89, 0.85, 0.82, 0.09, 0],
+    ],
+    provenance: PROVENANCE,
+};
+
+const LABEL_MAP = new Map([
+    ["a", "Alpha"],
+    ["b", "Beta"],
+    ["c", "Gamma"],
+    ["d", "Delta"],
+    ["e", "Epsilon"],
+    ["f", "Phi"],
+]);
+
+const TREE: QTreeResponse = {
+    nodes: [
+        {index: 0, label: "Alpha", connections: [4]},
+        {index: 1, label: "Beta", connections: [4]},
+        {index: 2, label: "Gamma", connections: [5]},
+        {index: 3, label: "Delta", connections: [5]},
+        {index: 4, label: "", connections: [0, 1, 5]},
+        {index: 5, label: "", connections: [2, 3, 4]},
+    ],
+    edgeSupport: {"4-5": 0.875},
+    balancedSplit: {
+        edgeKey: "4-5",
+        leftLeafIndices: [0, 1],
+        rightLeafIndices: [2, 3],
+        support: 0.875,
+    },
+    search: {
+        pipelineVersion: "qsearch-multistart-v2",
+        runCount: 16,
+        baseSeed: 1,
+        selectedSeed: 2,
+        selectedScore: 0.95,
+        scoreMinimum: 0.9,
+        scoreMean: 0.93,
+        scoreMaximum: 0.95,
+        selectedTopologyCount: 14,
+        selectedTopologySupport: 0.875,
+        uniqueTopologyCount: 2,
+        supportKind: "repeated-search-stability",
+    },
+};
+
+describe("explainable cluster report", () => {
+    test("renders a plain-language strong-separation report with direct evidence", () => {
+        render(<ClusterReport ncdMatrixResponse={STRONG_RESPONSE} labelMap={LABEL_MAP} qSearchTreeResult={TREE}/>);
+
+        expect(screen.getByRole("heading", {name: "Suggested structure"})).toBeInTheDocument();
+        expect(screen.getByText("Strong separation")).toBeInTheDocument();
+        expect(screen.getAllByText("Alpha + Beta")).toHaveLength(2);
+        expect(screen.getByText("NCD 0.100 · lower means closer")).toBeInTheDocument();
+        expect(screen.getByLabelText("2 suggested groups")).toBeInTheDocument();
+        expect(screen.getByText("LZMA compression")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText("Research details and limitations"));
+        expect(screen.getByText(/14 of 16 deterministic restarts \(88%\)/)).toBeInTheDocument();
+        expect(screen.getByText(/not bootstrap support or scientific confidence/)).toBeInTheDocument();
+        expect(screen.queryByText("qsearch-multistart-v2")).not.toBeInTheDocument();
+        expect(screen.queryByText("0.95")).not.toBeInTheDocument();
+    });
+
+    test("uses explicit exploratory language for an ambiguous matrix", () => {
+        render(<ClusterReport ncdMatrixResponse={WEAK_RESPONSE} labelMap={LABEL_MAP}/>);
+
+        expect(screen.getByText("Weak separation")).toBeInTheDocument();
+        expect(screen.getByText(/groups overlap.*exploratory/i)).toBeInTheDocument();
+        fireEvent.click(screen.getByText("Research details and limitations"));
+        const table = screen.getByRole("table", {name: "Silhouette evaluated for candidate group counts"});
+        expect(within(table).getAllByText("0.000").length).toBeGreaterThan(0);
+    });
+
+    test("allows a researcher to override and restore the suggested group count", () => {
+        render(<ClusterReport ncdMatrixResponse={THREE_GROUP_RESPONSE} labelMap={LABEL_MAP}/>);
+
+        const groupCount = screen.getByLabelText("Number of groups");
+        expect(groupCount).toHaveValue("3");
+        expect(screen.getByLabelText("3 suggested groups")).toBeInTheDocument();
+
+        fireEvent.change(groupCount, {target: {value: "2"}});
+        expect(screen.getByText("2 groups are shown by your selection.")).toBeInTheDocument();
+        expect(screen.getByLabelText("2 selected groups")).toBeInTheDocument();
+        expect(screen.getByRole("button", {name: "Use suggested 3"})).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", {name: "Use suggested 3"}));
+        expect(groupCount).toHaveValue("3");
+        expect(screen.getByLabelText("3 suggested groups")).toBeInTheDocument();
+    });
+
+    test("identifies imported matrices without inventing compressor provenance", () => {
+        render(
+            <ClusterReport
+                ncdMatrixResponse={{
+                    ...STRONG_RESPONSE,
+                    provenance: {
+                        ...PROVENANCE,
+                        source: "imported",
+                        algorithm: "unknown",
+                        directedMatrixForm: "unknown",
+                        matrixReduction: "unknown",
+                    },
+                }}
+                labelMap={LABEL_MAP}
+            />,
+        );
+
+        expect(screen.getByText("Imported distance matrix")).toBeInTheDocument();
+        expect(screen.queryByText("UNKNOWN compression")).not.toBeInTheDocument();
+    });
+});

--- a/ncd-calculator/src/__test__/kGridVisualizationLifecycle.test.tsx
+++ b/ncd-calculator/src/__test__/kGridVisualizationLifecycle.test.tsx
@@ -86,20 +86,9 @@ const LABEL_MAP = new Map([
 ]);
 
 describe("K-grid visualization lifecycle", () => {
-  test("stops K-grid status when the completed quartet result becomes active", async () => {
+  test("opens on the cluster report and stops K-grid work when the report becomes active", async () => {
     const onOptimizationEnd = vi.fn();
-    const {rerender} = render(
-      <KGridVisualization
-        ncdMatrixResponse={MATRIX}
-        objects={OBJECTS}
-        labelMap={LABEL_MAP}
-        onOptimizationEnd={onOptimizationEnd}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", {name: "Start mock K-grid"}));
-
-    rerender(
+    render(
       <KGridVisualization
         ncdMatrixResponse={MATRIX}
         objects={OBJECTS}
@@ -109,8 +98,15 @@ describe("K-grid visualization lifecycle", () => {
       />,
     );
 
+    expect(screen.getByRole("button", {name: "Cluster report"})).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("heading", {name: "Suggested structure"})).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", {name: "K-grid"}));
+    fireEvent.click(screen.getByRole("button", {name: "Start mock K-grid"}));
+    fireEvent.click(screen.getByRole("button", {name: "Cluster report"}));
+
     await waitFor(() => expect(onOptimizationEnd).toHaveBeenCalledTimes(1));
-    expect(screen.getByRole("button", {name: "Quartet tree"})).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", {name: "Cluster report"})).toHaveAttribute("aria-pressed", "true");
     expect(screen.queryByText(/Status:/)).not.toBeInTheDocument();
     expect(screen.queryByText("ncd-pipeline-v3")).not.toBeInTheDocument();
   });

--- a/ncd-calculator/src/components/ClusterReport.tsx
+++ b/ncd-calculator/src/components/ClusterReport.tsx
@@ -1,0 +1,237 @@
+import React, {useMemo, useState} from "react";
+import {buildClusterAnalysis} from "@/services/ClusterAnalysis";
+import {getDisplayLabel} from "@/services/DisplayLabelProtocol";
+import type {NCDMatrixResponse} from "@/types/ncd";
+import type {QTreeResponse} from "@/types/qsearch";
+
+interface ClusterReportProps {
+    readonly ncdMatrixResponse: NCDMatrixResponse;
+    readonly labelMap: ReadonlyMap<string, string>;
+    readonly qSearchTreeResult?: QTreeResponse;
+}
+
+const formatDistance = (value: number | null): string => value === null ? "Not available" : value.toFixed(3);
+const formatPercent = (value: number): string => `${Math.round(value * 100)}%`;
+
+const separationCopy = {
+    strong: "These groups are well separated relative to the distances inside each group.",
+    moderate: "These groups show some separation, although overlap remains possible.",
+    weak: "The objects can be partitioned, but the groups overlap. Treat this structure as exploratory.",
+} as const;
+
+export const ClusterReport: React.FC<ClusterReportProps> = ({
+    ncdMatrixResponse,
+    labelMap,
+    qSearchTreeResult,
+}) => {
+    const [manualClusterCount, setManualClusterCount] = useState<number | undefined>();
+    const displayLabels = useMemo(
+        () => ncdMatrixResponse.labels.map((id) => getDisplayLabel(labelMap, id)),
+        [labelMap, ncdMatrixResponse.labels],
+    );
+    const result = useMemo(() => {
+        try {
+            return {
+                analysis: buildClusterAnalysis({
+                    objectIds: ncdMatrixResponse.labels,
+                    displayLabels,
+                    ncdMatrix: ncdMatrixResponse.ncdMatrix,
+                    clusterCount: manualClusterCount,
+                }),
+                error: null,
+            };
+        } catch (error) {
+            return {
+                analysis: null,
+                error: error instanceof Error ? error.message : "Unable to construct the cluster report",
+            };
+        }
+    }, [displayLabels, manualClusterCount, ncdMatrixResponse.labels, ncdMatrixResponse.ncdMatrix]);
+
+    if (!result.analysis) {
+        return (
+            <div className="cluster-report cluster-report--error" role="alert">
+                <strong>Cluster report unavailable</strong>
+                <span>{result.error}</span>
+            </div>
+        );
+    }
+
+    const {analysis} = result;
+    const closestPair = analysis.closestPairs[0];
+    const provenance = ncdMatrixResponse.provenance.source === "computed"
+        ? `${ncdMatrixResponse.provenance.algorithm.toUpperCase()} compression`
+        : "Imported distance matrix";
+    const clusterCountOptions = Array.from(
+        {length: analysis.objectCount - 2},
+        (_, index) => index + 2,
+    );
+
+    return (
+        <section className="cluster-report" aria-labelledby="cluster-report-title">
+            <header className="cluster-report__header">
+                <div>
+                    <p className="cluster-report__eyebrow">Explainable cluster report</p>
+                    <h3 id="cluster-report-title">Suggested structure</h3>
+                    <p>{separationCopy[analysis.separation]}</p>
+                </div>
+                <div className="cluster-report__group-control">
+                    <label htmlFor="cluster-report-count">Number of groups</label>
+                    <select
+                        id="cluster-report-count"
+                        value={analysis.selectedClusterCount}
+                        onChange={(event) => setManualClusterCount(Number(event.target.value))}
+                    >
+                        {clusterCountOptions.map((clusterCount) => (
+                            <option key={clusterCount} value={clusterCount}>
+                                {clusterCount}{clusterCount === analysis.suggestedClusterCount ? " (suggested)" : ""}
+                            </option>
+                        ))}
+                    </select>
+                    {manualClusterCount !== undefined && manualClusterCount !== analysis.suggestedClusterCount && (
+                        <button type="button" onClick={() => setManualClusterCount(undefined)}>
+                            Use suggested {analysis.suggestedClusterCount}
+                        </button>
+                    )}
+                </div>
+            </header>
+
+            <div className={`cluster-report__assessment cluster-report__assessment--${analysis.separation}`} role="status">
+                <strong>{analysis.separation[0].toUpperCase() + analysis.separation.slice(1)} separation</strong>
+                <span>
+                    {analysis.selection === "suggested"
+                        ? `${analysis.suggestedClusterCount} groups are suggested by the strongest silhouette in the tested range.`
+                        : `${analysis.selectedClusterCount} groups are shown by your selection.`}
+                </span>
+            </div>
+
+            <div className="cluster-report__highlights" aria-label="Result highlights">
+                <article>
+                    <span>Closest relationship</span>
+                    <strong>{closestPair.firstLabel} + {closestPair.secondLabel}</strong>
+                    <small>NCD {formatDistance(closestPair.distance)} · lower means closer</small>
+                </article>
+                <article>
+                    <span>Most isolated object</span>
+                    <strong>{analysis.mostIsolatedObject.objectLabel}</strong>
+                    <small>Mean distance {formatDistance(analysis.mostIsolatedObject.meanDistance)} to all others</small>
+                </article>
+                <article>
+                    <span>Grouping model</span>
+                    <strong>Average linkage</strong>
+                    <small>{provenance}</small>
+                </article>
+            </div>
+
+            <div
+                className="cluster-report__groups"
+                aria-label={`${analysis.selectedClusterCount} ${analysis.selection === "suggested" ? "suggested" : "selected"} groups`}
+            >
+                {analysis.groups.map((group) => (
+                    <article className="cluster-report__group" key={group.memberIds.join("\u0000")}>
+                        <header>
+                            <span>Group {group.index + 1}</span>
+                            <small>{group.memberIds.length} {group.memberIds.length === 1 ? "object" : "objects"}</small>
+                        </header>
+                        <ul>
+                            {group.memberLabels.map((label, index) => (
+                                <li key={group.memberIds[index]}>{label}</li>
+                            ))}
+                        </ul>
+                        <p>
+                            {group.meanWithinDistance === null
+                                ? "Single-object group; no within-group distance."
+                                : `Average within-group NCD ${formatDistance(group.meanWithinDistance)}.`}
+                        </p>
+                    </article>
+                ))}
+            </div>
+
+            <section className="cluster-report__pairs" aria-labelledby="cluster-report-pairs-title">
+                <header>
+                    <h4 id="cluster-report-pairs-title">Closest pairs</h4>
+                    <span>Direct evidence from the distance matrix</span>
+                </header>
+                <ol>
+                    {analysis.closestPairs.map((pair) => (
+                        <li key={`${pair.firstId}\u0000${pair.secondId}`}>
+                            <span>{pair.firstLabel} + {pair.secondLabel}</span>
+                            <strong>{formatDistance(pair.distance)}</strong>
+                        </li>
+                    ))}
+                </ol>
+            </section>
+
+            <details className="cluster-report__research">
+                <summary>Research details and limitations</summary>
+                <div className="cluster-report__research-body">
+                    <p>
+                        Groups use deterministic average-linkage agglomerative clustering over the symmetric NCD matrix.
+                        The suggested count maximizes mean silhouette across 2 to {Math.min(analysis.objectCount - 1, 8)} groups.
+                        Silhouette describes separation in this dataset; it is not a confidence probability or proof of a real-world class.
+                    </p>
+
+                    <dl className="cluster-report__metrics">
+                        <div>
+                            <dt>Selected silhouette</dt>
+                            <dd>{analysis.silhouette.toFixed(3)}</dd>
+                        </div>
+                        <div>
+                            <dt>Mean within-group NCD</dt>
+                            <dd>{formatDistance(analysis.meanWithinDistance)}</dd>
+                        </div>
+                        <div>
+                            <dt>Mean between-group NCD</dt>
+                            <dd>{formatDistance(analysis.meanBetweenDistance)}</dd>
+                        </div>
+                    </dl>
+
+                    <div className="cluster-report__candidate-table">
+                        <table>
+                            <caption>Silhouette evaluated for candidate group counts</caption>
+                            <thead>
+                            <tr>
+                                <th scope="col">Groups</th>
+                                <th scope="col">Silhouette</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {analysis.candidates.map((candidate) => (
+                                <tr key={candidate.clusterCount}>
+                                    <th scope="row">{candidate.clusterCount}</th>
+                                    <td>{candidate.silhouette.toFixed(3)}</td>
+                                </tr>
+                            ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div className="cluster-report__nearest-neighbors">
+                        <h4>Nearest neighbor for every object</h4>
+                        <ul>
+                            {analysis.nearestNeighbors.map((neighbor) => (
+                                <li key={neighbor.objectId}>
+                                    <span>{neighbor.objectLabel} → {neighbor.neighborLabel}</span>
+                                    <strong>{formatDistance(neighbor.distance)}</strong>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    {qSearchTreeResult && (
+                        <div className="cluster-report__stability">
+                            <h4>Quartet-tree search stability</h4>
+                            <p>
+                                The selected QSearch topology appeared in {qSearchTreeResult.search.selectedTopologyCount} of{" "}
+                                {qSearchTreeResult.search.runCount} deterministic restarts ({formatPercent(qSearchTreeResult.search.selectedTopologySupport)}).
+                                This measures optimization repeatability, not bootstrap support or scientific confidence in the groups.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </details>
+        </section>
+    );
+};
+
+export default ClusterReport;

--- a/ncd-calculator/src/components/KGridVisualization.tsx
+++ b/ncd-calculator/src/components/KGridVisualization.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {ClusterReport} from "@/components/ClusterReport";
 import {KGridDualOptimization} from './KGridDualOptimization';
 import {QSearchTree3D} from './QSearchTree3D';
 import type {QTreeResponse} from "@/types/qsearch";
@@ -9,6 +10,7 @@ import type {NCDMatrixResponse} from "@/types/ncd";
 
 // Visualization types enum for better type safety
 export const VisualizationType = {
+    REPORT: "report",
     QUARTET: "quartet",
     KGRID: "kgrid",
     MATRIX: "matrix"
@@ -45,29 +47,14 @@ const KGridVisualization: React.FC<KGridVisualizationProps> = ({
                                                                    labelMap,
                                                                    errorMsg
                                                                }) => {
-    // Default to QUARTET view, fallback to others if available
-    const getDefaultView = (): VisualizationTypeValue => {
-        if (qSearchTreeResult && Object.keys(qSearchTreeResult).length > 0) {
-            return VisualizationType.QUARTET;
-        }
-        return VisualizationType.KGRID;
-    };
-
     // State management
-    const [activeViz, setActiveViz] = useState<VisualizationTypeValue>(getDefaultView());
+    const [activeViz, setActiveViz] = useState<VisualizationTypeValue>(VisualizationType.REPORT);
     const [selectedTheme, setSelectedTheme] = useState("scientific");
     const [isRunning, setIsRunning] = useState(false);
     const [showHelp, setShowHelp] = useState(false);
 
     // Track if optimization has been started manually
     const manuallyStartedRef = useRef(false);
-
-    // Update default view when tree data becomes available
-    useEffect(() => {
-        if (qSearchTreeResult && Object.keys(qSearchTreeResult).length > 0) {
-            setActiveViz(VisualizationType.QUARTET);
-        }
-    }, [qSearchTreeResult]);
 
     // Use a ref to track running state to avoid closure issues
     const isRunningRef = useRef<boolean>(false);
@@ -208,6 +195,14 @@ const KGridVisualization: React.FC<KGridVisualizationProps> = ({
     // Get content for current visualization type
     const renderVisualizationContent = () => {
         switch (activeViz) {
+            case VisualizationType.REPORT:
+                return (
+                    <ClusterReport
+                        ncdMatrixResponse={ncdMatrixResponse}
+                        labelMap={labelMap}
+                        qSearchTreeResult={qSearchTreeResult}
+                    />
+                );
             case VisualizationType.KGRID:
                 return renderKGridContent();
             case VisualizationType.MATRIX:
@@ -230,27 +225,34 @@ const KGridVisualization: React.FC<KGridVisualizationProps> = ({
 
             {/* Visualization Type Selector */}
             <nav className="ncd-visualization__tabs" aria-label="Result view">
-                    <button
-                        type="button"
-                        onClick={() => setActiveViz(VisualizationType.QUARTET)}
-                        aria-pressed={activeViz === VisualizationType.QUARTET}
-                    >
-                        Quartet tree
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => setActiveViz(VisualizationType.KGRID)}
-                        aria-pressed={activeViz === VisualizationType.KGRID}
-                    >
-                        K-grid
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => setActiveViz(VisualizationType.MATRIX)}
-                        aria-pressed={activeViz === VisualizationType.MATRIX}
-                    >
-                        Distance matrix
-                    </button>
+                <button
+                    type="button"
+                    onClick={() => setActiveViz(VisualizationType.REPORT)}
+                    aria-pressed={activeViz === VisualizationType.REPORT}
+                >
+                    Cluster report
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setActiveViz(VisualizationType.QUARTET)}
+                    aria-pressed={activeViz === VisualizationType.QUARTET}
+                >
+                    Quartet tree
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setActiveViz(VisualizationType.KGRID)}
+                    aria-pressed={activeViz === VisualizationType.KGRID}
+                >
+                    K-grid
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setActiveViz(VisualizationType.MATRIX)}
+                    aria-pressed={activeViz === VisualizationType.MATRIX}
+                >
+                    Distance matrix
+                </button>
             </nav>
 
 
@@ -337,11 +339,14 @@ const KGridVisualization: React.FC<KGridVisualizationProps> = ({
                         <div className="bg-gray-800 p-4 border-l-4 border-yellow-500 mb-4 text-white text-left">
                             <h3 className="font-bold text-lg mb-2 text-yellow-300 text-center">Reading NCD outputs</h3>
                             <p className="mb-2 text-base">
-                                This tool presents relationships among the selected objects in three forms:
+                                This tool presents relationships among the selected objects in four forms:
                             </p>
                             <ul className="text-left">
+                                <li className="mb-1"><strong className="text-yellow-300">Cluster Report:</strong> Summarizes
+                                    suggested groups, closest pairs, separation, and research limitations in text.
+                                </li>
                                 <li className="mb-1"><strong className="text-yellow-300">Quartet Tree:</strong> Displays
-                                    relationships as a hierarchical tree structure showing evolutionary relationships.
+                                    global relationships as an unrooted topology without asserting evolutionary ancestry.
                                 </li>
                                 <li className="mb-1"><strong className="text-yellow-300">K-Grid:</strong> Arranges items
                                     in a grid where similar items are placed close together. The optimization process

--- a/ncd-calculator/src/components/Workbench.css
+++ b/ncd-calculator/src/components/Workbench.css
@@ -786,6 +786,356 @@
     overflow: auto;
 }
 
+.cluster-report {
+    display: grid;
+    gap: 18px;
+    padding: clamp(18px, 3vw, 30px);
+    color: #17231d;
+    background: #f7f3e8;
+    border: 1px solid #53635a;
+}
+
+.cluster-report--error {
+    color: #6e2514;
+    border-left: 4px solid #a6462b;
+}
+
+.cluster-report--error span {
+    display: block;
+}
+
+.cluster-report__header {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 28px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid #7e877f;
+}
+
+.cluster-report__eyebrow,
+.cluster-report__highlights span,
+.cluster-report__group header span,
+.cluster-report__pairs header span {
+    margin: 0 0 7px;
+    color: #5c675f;
+    font-family: var(--font-mono);
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.055em;
+    text-transform: uppercase;
+}
+
+.cluster-report__header h3 {
+    margin: 0;
+    color: #173c2e;
+    font-family: var(--font-serif);
+    font-size: clamp(1.55rem, 3vw, 2.25rem);
+    font-weight: 500;
+    letter-spacing: -0.03em;
+}
+
+.cluster-report__header p:last-child {
+    max-width: 680px;
+    margin: 8px 0 0;
+    color: #3b463f;
+    font-size: 0.83rem;
+    line-height: 1.55;
+}
+
+.cluster-report__group-control {
+    min-width: 190px;
+    display: grid;
+    gap: 7px;
+}
+
+.cluster-report__group-control label {
+    color: #3b463f;
+    font-family: var(--font-mono);
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.cluster-report__group-control select,
+.cluster-report__group-control button {
+    min-height: 38px;
+    padding: 8px 10px;
+    color: #17231d;
+    background: #fffdf7;
+    border: 1px solid #53635a;
+    border-radius: 0;
+    font-size: 0.74rem;
+    font-weight: 700;
+}
+
+.cluster-report__group-control button:hover,
+.cluster-report__group-control button:focus-visible {
+    color: #fffdf7;
+    background: #173c2e;
+}
+
+.cluster-report__assessment {
+    display: grid;
+    grid-template-columns: minmax(130px, 0.3fr) minmax(0, 1fr);
+    gap: 16px;
+    padding: 13px 15px;
+    color: #17231d;
+    border-left: 4px solid #315b4b;
+    background: #e4ebe4;
+    font-size: 0.78rem;
+}
+
+.cluster-report__assessment--moderate {
+    border-left-color: #9b6334;
+    background: #f1e7d6;
+}
+
+.cluster-report__assessment--weak {
+    border-left-color: #a6462b;
+    background: #f3dfd7;
+}
+
+.cluster-report__highlights {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border-top: 1px solid #7e877f;
+    border-left: 1px solid #7e877f;
+}
+
+.cluster-report__highlights article {
+    min-width: 0;
+    display: grid;
+    align-content: start;
+    gap: 5px;
+    padding: 16px;
+    background: #fffdf7;
+    border-right: 1px solid #7e877f;
+    border-bottom: 1px solid #7e877f;
+}
+
+.cluster-report__highlights strong {
+    color: #173c2e;
+    font-size: 0.89rem;
+    overflow-wrap: anywhere;
+}
+
+.cluster-report__highlights small {
+    color: #5c675f;
+    font-size: 0.7rem;
+    line-height: 1.45;
+}
+
+.cluster-report__groups {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+}
+
+.cluster-report__group {
+    min-width: 0;
+    background: #fffdf7;
+    border: 1px solid #7e877f;
+}
+
+.cluster-report__group header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 11px 13px;
+    border-bottom: 1px solid #b5b9b2;
+}
+
+.cluster-report__group header span {
+    margin: 0;
+    color: #173c2e;
+}
+
+.cluster-report__group header small {
+    color: #5c675f;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+}
+
+.cluster-report__group ul {
+    display: grid;
+    gap: 7px;
+    margin: 0;
+    padding: 13px 13px 12px 30px;
+    color: #17231d;
+    font-size: 0.78rem;
+}
+
+.cluster-report__group p {
+    margin: 0;
+    padding: 10px 13px;
+    color: #5c675f;
+    background: #eeeadd;
+    border-top: 1px solid #b5b9b2;
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    line-height: 1.45;
+}
+
+.cluster-report__pairs {
+    background: #fffdf7;
+    border: 1px solid #7e877f;
+}
+
+.cluster-report__pairs header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 13px 15px;
+    border-bottom: 1px solid #b5b9b2;
+}
+
+.cluster-report__pairs h4,
+.cluster-report__nearest-neighbors h4,
+.cluster-report__stability h4 {
+    margin: 0;
+    color: #173c2e;
+    font-size: 0.82rem;
+}
+
+.cluster-report__pairs header span {
+    margin: 0;
+}
+
+.cluster-report__pairs ol,
+.cluster-report__nearest-neighbors ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.cluster-report__pairs li,
+.cluster-report__nearest-neighbors li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 10px 15px;
+    border-bottom: 1px solid #d2d2ca;
+    font-size: 0.74rem;
+}
+
+.cluster-report__pairs li:last-child,
+.cluster-report__nearest-neighbors li:last-child {
+    border-bottom: 0;
+}
+
+.cluster-report__pairs li strong,
+.cluster-report__nearest-neighbors li strong {
+    color: #173c2e;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+}
+
+.cluster-report__research {
+    background: #eeeadd;
+    border: 1px solid #7e877f;
+}
+
+.cluster-report__research summary {
+    padding: 13px 15px;
+    color: #173c2e;
+    cursor: pointer;
+    font-size: 0.76rem;
+    font-weight: 750;
+}
+
+.cluster-report__research-body {
+    display: grid;
+    gap: 18px;
+    padding: 0 15px 16px;
+    color: #3b463f;
+    border-top: 1px solid #b5b9b2;
+    font-size: 0.75rem;
+    line-height: 1.6;
+}
+
+.cluster-report__research-body > p {
+    margin: 15px 0 0;
+}
+
+.cluster-report__metrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin: 0;
+    border-top: 1px solid #b5b9b2;
+    border-left: 1px solid #b5b9b2;
+}
+
+.cluster-report__metrics div {
+    padding: 11px;
+    background: #fffdf7;
+    border-right: 1px solid #b5b9b2;
+    border-bottom: 1px solid #b5b9b2;
+}
+
+.cluster-report__metrics dt {
+    color: #5c675f;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+}
+
+.cluster-report__metrics dd {
+    margin: 5px 0 0;
+    color: #173c2e;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+
+.cluster-report__candidate-table {
+    overflow-x: auto;
+}
+
+.cluster-report__candidate-table table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fffdf7;
+}
+
+.cluster-report__candidate-table caption {
+    padding: 9px 11px;
+    color: #173c2e;
+    font-weight: 700;
+    text-align: left;
+}
+
+.cluster-report__candidate-table th,
+.cluster-report__candidate-table td {
+    padding: 8px 11px;
+    border: 1px solid #b5b9b2;
+    text-align: left;
+}
+
+.cluster-report__nearest-neighbors,
+.cluster-report__stability {
+    background: #fffdf7;
+    border: 1px solid #b5b9b2;
+}
+
+.cluster-report__nearest-neighbors h4,
+.cluster-report__stability h4,
+.cluster-report__stability p {
+    padding: 11px 13px;
+}
+
+.cluster-report__stability h4 {
+    border-bottom: 1px solid #b5b9b2;
+}
+
+.cluster-report__stability p {
+    margin: 0;
+}
+
 .ncd-visualization__canvas,
 .ncd-visualization__pending {
     min-height: 480px;
@@ -1417,6 +1767,30 @@ button.genbank-suggestions__status:hover {
     }
 
     .ncd-visualization__body {
+        flex-direction: column;
+    }
+
+    .cluster-report__header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .cluster-report__group-control {
+        min-width: 0;
+    }
+
+    .cluster-report__highlights,
+    .cluster-report__metrics {
+        grid-template-columns: 1fr;
+    }
+
+    .cluster-report__assessment {
+        grid-template-columns: 1fr;
+        gap: 4px;
+    }
+
+    .cluster-report__pairs header {
+        align-items: flex-start;
         flex-direction: column;
     }
 

--- a/ncd-calculator/src/services/ClusterAnalysis.ts
+++ b/ncd-calculator/src/services/ClusterAnalysis.ts
@@ -1,0 +1,375 @@
+import {validateMatrix} from "@/functions/matrix";
+import type {
+    ClusterAnalysisInput,
+    ClusterAnalysisResult,
+    ClusterCountCandidate,
+    ClusterGroupSummary,
+    ClusterPairSummary,
+    ClusterSeparation,
+    IsolatedObjectSummary,
+    NearestNeighborSummary,
+} from "@/types/clusterAnalysis";
+
+export const CLUSTER_ANALYSIS_METHOD = "average-linkage-v1" as const;
+export const MAX_SUGGESTED_CLUSTER_COUNT = 8;
+export const MAX_CLOSEST_PAIR_COUNT = 5;
+
+interface ActiveCluster {
+    readonly id: number;
+    readonly members: number[];
+    readonly signature: string;
+}
+
+interface ClusterMerge {
+    readonly leftId: number;
+    readonly rightId: number;
+    readonly mergedId: number;
+    readonly members: number[];
+}
+
+interface Dendrogram {
+    readonly merges: ClusterMerge[];
+}
+
+const DISTANCE_TIE_TOLERANCE = 1e-12;
+const SILHOUETTE_TIE_TOLERANCE = 1e-12;
+const compareText = (left: string, right: string): number => left.localeCompare(right, "en");
+const pairKey = (first: number, second: number): string => (
+    `${Math.min(first, second)}:${Math.max(first, second)}`
+);
+
+const mean = (values: readonly number[]): number | null => {
+    if (values.length === 0) return null;
+    return values.reduce((total, value) => total + value, 0) / values.length;
+};
+
+const assertInput = ({objectIds, displayLabels, ncdMatrix}: ClusterAnalysisInput): void => {
+    const ids = [...objectIds];
+    const matrix = ncdMatrix.map((row) => [...row]);
+    const matrixError = validateMatrix(ids, matrix);
+    if (matrixError) throw new Error(`Cannot analyze an invalid NCD matrix: ${matrixError}`);
+    if (objectIds.length < 3) throw new Error("Cluster analysis requires at least three objects");
+    if (displayLabels.length !== objectIds.length) {
+        throw new Error("Display labels must match the number of object identifiers");
+    }
+    if (displayLabels.some((label) => typeof label !== "string" || label.trim().length === 0)) {
+        throw new Error("Display labels must be non-empty strings");
+    }
+};
+
+const makeSignature = (members: readonly number[], objectIds: readonly string[]): string => (
+    members.map((index) => objectIds[index]).sort(compareText).join("\u0000")
+);
+
+const orderClusterPair = (first: ActiveCluster, second: ActiveCluster): [ActiveCluster, ActiveCluster] => (
+    compareText(first.signature, second.signature) <= 0 ? [first, second] : [second, first]
+);
+
+const buildDendrogram = (
+    objectIds: readonly string[],
+    ncdMatrix: readonly (readonly number[])[],
+): Dendrogram => {
+    const active = new Map<number, ActiveCluster>();
+    const distances = new Map<string, number>();
+    objectIds.forEach((_, index) => {
+        active.set(index, {id: index, members: [index], signature: objectIds[index]});
+    });
+    for (let first = 0; first < objectIds.length; first += 1) {
+        for (let second = first + 1; second < objectIds.length; second += 1) {
+            distances.set(pairKey(first, second), ncdMatrix[first][second]);
+        }
+    }
+
+    const merges: ClusterMerge[] = [];
+    let nextClusterId = objectIds.length;
+    while (active.size > 1) {
+        const clusters = [...active.values()].sort((left, right) => compareText(left.signature, right.signature));
+        let selected: {left: ActiveCluster; right: ActiveCluster; distance: number; tieKey: string} | null = null;
+
+        for (let first = 0; first < clusters.length; first += 1) {
+            for (let second = first + 1; second < clusters.length; second += 1) {
+                const [left, right] = orderClusterPair(clusters[first], clusters[second]);
+                const distance = distances.get(pairKey(left.id, right.id));
+                if (distance === undefined) throw new Error("Cluster distance state is incomplete");
+                const tieKey = `${left.signature}\u0001${right.signature}`;
+                if (
+                    !selected
+                    || distance < selected.distance - DISTANCE_TIE_TOLERANCE
+                    || (
+                        Math.abs(distance - selected.distance) <= DISTANCE_TIE_TOLERANCE
+                        && compareText(tieKey, selected.tieKey) < 0
+                    )
+                ) {
+                    selected = {left, right, distance, tieKey};
+                }
+            }
+        }
+        if (!selected) throw new Error("Cluster analysis could not select a merge");
+
+        const members = [...selected.left.members, ...selected.right.members]
+            .sort((left, right) => compareText(objectIds[left], objectIds[right]));
+        const merged: ActiveCluster = {
+            id: nextClusterId,
+            members,
+            signature: makeSignature(members, objectIds),
+        };
+
+        for (const other of active.values()) {
+            if (other.id === selected.left.id || other.id === selected.right.id) continue;
+            const leftDistance = distances.get(pairKey(selected.left.id, other.id));
+            const rightDistance = distances.get(pairKey(selected.right.id, other.id));
+            if (leftDistance === undefined || rightDistance === undefined) {
+                throw new Error("Cluster distance state is incomplete during merge");
+            }
+            const mergedDistance = (
+                leftDistance * selected.left.members.length
+                + rightDistance * selected.right.members.length
+            ) / members.length;
+            distances.set(pairKey(merged.id, other.id), mergedDistance);
+        }
+
+        active.delete(selected.left.id);
+        active.delete(selected.right.id);
+        active.set(merged.id, merged);
+        merges.push({
+            leftId: selected.left.id,
+            rightId: selected.right.id,
+            mergedId: merged.id,
+            members,
+        });
+        nextClusterId += 1;
+    }
+    return {merges};
+};
+
+const cutDendrogram = (
+    objectCount: number,
+    dendrogram: Dendrogram,
+    clusterCount: number,
+    objectIds: readonly string[],
+): number[][] => {
+    const active = new Map<number, number[]>();
+    for (let index = 0; index < objectCount; index += 1) active.set(index, [index]);
+    for (const merge of dendrogram.merges) {
+        if (active.size <= clusterCount) break;
+        if (!active.has(merge.leftId) || !active.has(merge.rightId)) {
+            throw new Error("Dendrogram contains an invalid merge order");
+        }
+        active.delete(merge.leftId);
+        active.delete(merge.rightId);
+        active.set(merge.mergedId, merge.members);
+    }
+    if (active.size !== clusterCount) throw new Error("Dendrogram could not produce the requested cluster count");
+    return [...active.values()]
+        .map((members) => [...members].sort((left, right) => compareText(objectIds[left], objectIds[right])))
+        .sort((left, right) => compareText(makeSignature(left, objectIds), makeSignature(right, objectIds)));
+};
+
+const calculateSilhouette = (
+    groups: readonly (readonly number[])[],
+    ncdMatrix: readonly (readonly number[])[],
+): number => {
+    const clusterByObject = new Map<number, number>();
+    groups.forEach((members, groupIndex) => {
+        members.forEach((member) => clusterByObject.set(member, groupIndex));
+    });
+
+    const values = ncdMatrix.map((_, objectIndex) => {
+        const groupIndex = clusterByObject.get(objectIndex);
+        if (groupIndex === undefined) throw new Error("Cluster partition does not contain every object");
+        const ownGroup = groups[groupIndex];
+        if (ownGroup.length <= 1) return 0;
+        const within = ownGroup
+            .filter((member) => member !== objectIndex)
+            .map((member) => ncdMatrix[objectIndex][member]);
+        const averageWithin = mean(within);
+        if (averageWithin === null) return 0;
+        const averageOtherGroups = groups
+            .filter((_, candidateIndex) => candidateIndex !== groupIndex)
+            .map((members) => mean(members.map((member) => ncdMatrix[objectIndex][member])))
+            .filter((value): value is number => value !== null);
+        const nearestOther = Math.min(...averageOtherGroups);
+        const denominator = Math.max(averageWithin, nearestOther);
+        return denominator === 0 ? 0 : (nearestOther - averageWithin) / denominator;
+    });
+    return mean(values) ?? 0;
+};
+
+const getSeparation = (silhouette: number): ClusterSeparation => {
+    if (silhouette >= 0.5) return "strong";
+    if (silhouette >= 0.25) return "moderate";
+    return "weak";
+};
+
+const getClosestPairs = (
+    objectIds: readonly string[],
+    displayLabels: readonly string[],
+    ncdMatrix: readonly (readonly number[])[],
+): ClusterPairSummary[] => {
+    const pairs: ClusterPairSummary[] = [];
+    for (let firstIndex = 0; firstIndex < objectIds.length; firstIndex += 1) {
+        for (let secondIndex = firstIndex + 1; secondIndex < objectIds.length; secondIndex += 1) {
+            const orderedIndices = compareText(objectIds[firstIndex], objectIds[secondIndex]) <= 0
+                ? [firstIndex, secondIndex]
+                : [secondIndex, firstIndex];
+            const [orderedFirst, orderedSecond] = orderedIndices;
+            pairs.push({
+                firstIndex: orderedFirst,
+                secondIndex: orderedSecond,
+                firstId: objectIds[orderedFirst],
+                secondId: objectIds[orderedSecond],
+                firstLabel: displayLabels[orderedFirst],
+                secondLabel: displayLabels[orderedSecond],
+                distance: ncdMatrix[firstIndex][secondIndex],
+            });
+        }
+    }
+    return pairs.sort((left, right) => (
+        left.distance - right.distance
+        || compareText(`${left.firstId}\u0000${left.secondId}`, `${right.firstId}\u0000${right.secondId}`)
+    )).slice(0, MAX_CLOSEST_PAIR_COUNT);
+};
+
+const getNearestNeighbors = (
+    objectIds: readonly string[],
+    displayLabels: readonly string[],
+    ncdMatrix: readonly (readonly number[])[],
+): NearestNeighborSummary[] => objectIds.map((objectId, objectIndex) => {
+    const candidates = objectIds
+        .map((neighborId, neighborIndex) => ({neighborId, neighborIndex}))
+        .filter(({neighborIndex}) => neighborIndex !== objectIndex)
+        .sort((left, right) => (
+            ncdMatrix[objectIndex][left.neighborIndex] - ncdMatrix[objectIndex][right.neighborIndex]
+            || compareText(left.neighborId, right.neighborId)
+        ));
+    const nearest = candidates[0];
+    return {
+        objectIndex,
+        objectId,
+        objectLabel: displayLabels[objectIndex],
+        neighborIndex: nearest.neighborIndex,
+        neighborId: nearest.neighborId,
+        neighborLabel: displayLabels[nearest.neighborIndex],
+        distance: ncdMatrix[objectIndex][nearest.neighborIndex],
+    };
+}).sort((left, right) => compareText(left.objectId, right.objectId));
+
+const getMostIsolatedObject = (
+    objectIds: readonly string[],
+    displayLabels: readonly string[],
+    ncdMatrix: readonly (readonly number[])[],
+): IsolatedObjectSummary => {
+    const objects = objectIds.map((objectId, objectIndex) => ({
+        objectIndex,
+        objectId,
+        objectLabel: displayLabels[objectIndex],
+        meanDistance: mean(ncdMatrix[objectIndex].filter((_, otherIndex) => otherIndex !== objectIndex)) ?? 0,
+    }));
+    return objects.sort((left, right) => (
+        right.meanDistance - left.meanDistance || compareText(left.objectId, right.objectId)
+    ))[0];
+};
+
+const crossGroupMean = (
+    first: readonly number[],
+    second: readonly number[],
+    ncdMatrix: readonly (readonly number[])[],
+): number => mean(first.flatMap((left) => second.map((right) => ncdMatrix[left][right]))) ?? 0;
+
+const buildGroupSummaries = (
+    groups: readonly (readonly number[])[],
+    objectIds: readonly string[],
+    displayLabels: readonly string[],
+    ncdMatrix: readonly (readonly number[])[],
+): ClusterGroupSummary[] => groups.map((members, groupIndex) => {
+    const withinDistances: number[] = [];
+    for (let first = 0; first < members.length; first += 1) {
+        for (let second = first + 1; second < members.length; second += 1) {
+            withinDistances.push(ncdMatrix[members[first]][members[second]]);
+        }
+    }
+    const otherGroups = groups
+        .map((candidate, candidateIndex) => ({
+            candidateIndex,
+            distance: candidateIndex === groupIndex ? Number.POSITIVE_INFINITY : crossGroupMean(members, candidate, ncdMatrix),
+        }))
+        .filter(({candidateIndex}) => candidateIndex !== groupIndex)
+        .sort((left, right) => left.distance - right.distance || left.candidateIndex - right.candidateIndex);
+    const nearestGroup = otherGroups[0];
+    return {
+        index: groupIndex,
+        memberIndices: [...members],
+        memberIds: members.map((member) => objectIds[member]),
+        memberLabels: members.map((member) => displayLabels[member]),
+        meanWithinDistance: mean(withinDistances),
+        nearestGroupIndex: nearestGroup?.candidateIndex ?? null,
+        meanDistanceToNearestGroup: nearestGroup?.distance ?? null,
+    };
+});
+
+const getOverallDistanceMeans = (
+    groups: readonly (readonly number[])[],
+    ncdMatrix: readonly (readonly number[])[],
+): {meanWithinDistance: number | null; meanBetweenDistance: number | null} => {
+    const clusterByObject = new Map<number, number>();
+    groups.forEach((members, groupIndex) => members.forEach((member) => clusterByObject.set(member, groupIndex)));
+    const within: number[] = [];
+    const between: number[] = [];
+    for (let first = 0; first < ncdMatrix.length; first += 1) {
+        for (let second = first + 1; second < ncdMatrix.length; second += 1) {
+            const destination = clusterByObject.get(first) === clusterByObject.get(second) ? within : between;
+            destination.push(ncdMatrix[first][second]);
+        }
+    }
+    return {meanWithinDistance: mean(within), meanBetweenDistance: mean(between)};
+};
+
+export const buildClusterAnalysis = (input: ClusterAnalysisInput): ClusterAnalysisResult => {
+    assertInput(input);
+    const {objectIds, displayLabels, ncdMatrix} = input;
+    const dendrogram = buildDendrogram(objectIds, ncdMatrix);
+    const maximumCandidateCount = Math.min(MAX_SUGGESTED_CLUSTER_COUNT, objectIds.length - 1);
+    const candidates: ClusterCountCandidate[] = [];
+    for (let clusterCount = 2; clusterCount <= maximumCandidateCount; clusterCount += 1) {
+        const groups = cutDendrogram(objectIds.length, dendrogram, clusterCount, objectIds);
+        candidates.push({clusterCount, silhouette: calculateSilhouette(groups, ncdMatrix)});
+    }
+    const suggested = [...candidates].sort((left, right) => {
+        const difference = right.silhouette - left.silhouette;
+        return Math.abs(difference) > SILHOUETTE_TIE_TOLERANCE
+            ? difference
+            : left.clusterCount - right.clusterCount;
+    })[0];
+    if (!suggested) throw new Error("Cluster analysis could not evaluate a suggested partition");
+
+    const selectedClusterCount = input.clusterCount ?? suggested.clusterCount;
+    if (
+        !Number.isInteger(selectedClusterCount)
+        || selectedClusterCount < 2
+        || selectedClusterCount >= objectIds.length
+    ) {
+        throw new Error(`Cluster count must be an integer between 2 and ${objectIds.length - 1}`);
+    }
+    const groups = cutDendrogram(objectIds.length, dendrogram, selectedClusterCount, objectIds);
+    const silhouette = selectedClusterCount === suggested.clusterCount
+        ? suggested.silhouette
+        : calculateSilhouette(groups, ncdMatrix);
+    const groupSummaries = buildGroupSummaries(groups, objectIds, displayLabels, ncdMatrix);
+    const distanceMeans = getOverallDistanceMeans(groups, ncdMatrix);
+
+    return {
+        method: CLUSTER_ANALYSIS_METHOD,
+        objectCount: objectIds.length,
+        selectedClusterCount,
+        suggestedClusterCount: suggested.clusterCount,
+        selection: input.clusterCount === undefined ? "suggested" : "manual",
+        silhouette,
+        separation: getSeparation(silhouette),
+        candidates,
+        groups: groupSummaries,
+        closestPairs: getClosestPairs(objectIds, displayLabels, ncdMatrix),
+        nearestNeighbors: getNearestNeighbors(objectIds, displayLabels, ncdMatrix),
+        mostIsolatedObject: getMostIsolatedObject(objectIds, displayLabels, ncdMatrix),
+        ...distanceMeans,
+    };
+};

--- a/ncd-calculator/src/types/clusterAnalysis.ts
+++ b/ncd-calculator/src/types/clusterAnalysis.ts
@@ -1,0 +1,67 @@
+export type ClusterSeparation = "strong" | "moderate" | "weak";
+
+export interface ClusterCountCandidate {
+    readonly clusterCount: number;
+    readonly silhouette: number;
+}
+
+export interface ClusterPairSummary {
+    readonly firstIndex: number;
+    readonly secondIndex: number;
+    readonly firstId: string;
+    readonly secondId: string;
+    readonly firstLabel: string;
+    readonly secondLabel: string;
+    readonly distance: number;
+}
+
+export interface NearestNeighborSummary {
+    readonly objectIndex: number;
+    readonly objectId: string;
+    readonly objectLabel: string;
+    readonly neighborIndex: number;
+    readonly neighborId: string;
+    readonly neighborLabel: string;
+    readonly distance: number;
+}
+
+export interface ClusterGroupSummary {
+    readonly index: number;
+    readonly memberIndices: number[];
+    readonly memberIds: string[];
+    readonly memberLabels: string[];
+    readonly meanWithinDistance: number | null;
+    readonly nearestGroupIndex: number | null;
+    readonly meanDistanceToNearestGroup: number | null;
+}
+
+export interface IsolatedObjectSummary {
+    readonly objectIndex: number;
+    readonly objectId: string;
+    readonly objectLabel: string;
+    readonly meanDistance: number;
+}
+
+export interface ClusterAnalysisResult {
+    readonly method: "average-linkage-v1";
+    readonly objectCount: number;
+    readonly selectedClusterCount: number;
+    readonly suggestedClusterCount: number;
+    readonly selection: "suggested" | "manual";
+    readonly silhouette: number;
+    readonly separation: ClusterSeparation;
+    readonly candidates: ClusterCountCandidate[];
+    readonly groups: ClusterGroupSummary[];
+    readonly closestPairs: ClusterPairSummary[];
+    readonly nearestNeighbors: NearestNeighborSummary[];
+    readonly mostIsolatedObject: IsolatedObjectSummary;
+    readonly meanWithinDistance: number | null;
+    readonly meanBetweenDistance: number | null;
+}
+
+export interface ClusterAnalysisInput {
+    readonly objectIds: readonly string[];
+    readonly displayLabels: readonly string[];
+    readonly ncdMatrix: readonly (readonly number[])[];
+    readonly clusterCount?: number;
+}


### PR DESCRIPTION
## What

- make an explainable cluster report the default NCD result view
- add deterministic average-linkage grouping with stable identifier tie-breaking
- suggest a group count by mean silhouette while allowing researchers to inspect another dendrogram cut
- report group membership, closest pairs, relative isolation, within/between distances, provenance, and per-object nearest neighbors
- disclose QSearch topology recurrence only as optimization repeatability, not bootstrap support or scientific confidence
- document the method, interpretation limits, UI policy, and architecture

## Why

The distance matrix, tree, and K-grid are powerful but require substantial interpretation. This report gives lay users a direct answer to “what is close and how clear are the groups?” while keeping the numerical evidence and limitations researchers need to audit the result.

## Scenario coverage

Tests exercise strong two-pair structure, moderate separation, uniform ambiguous distances, a relatively isolated object, three compact groups with a manual cut, row/column permutation invariance, imported provenance, QSearch calibration, invalid asymmetric input, and result-view lifecycle behavior.

## Validation

- `npm test` — 40 files, 257 tests passed
- focused report suite — 3 files, 14 tests passed
- `npm run build` — corpus, export-schema, worker, Vite production, and bundle verification passed
- browser smoke test — bundled sequence example, manual group override/reset, research disclosure, and 360 px responsive layout verified

## Known baseline

`npm run typecheck` still fails on existing `main` issues in legacy files such as `FileDrop.tsx`, tree components, and `libs/lzma.ts`. The compiler reported no errors in the new report, analysis, type, or modified result-view files.
