### PR TITLE
Default completed results to quartet tree

### DIFF
--- a/ncd-calculator/src/__test__/kGridVisualizationLifecycle.test.tsx
+++ b/ncd-calculator/src/__test__/kGridVisualizationLifecycle.test.tsx
@@ -86,7 +86,7 @@ const LABEL_MAP = new Map([
 ]);
 
 describe("K-grid visualization lifecycle", () => {
-  test("opens on the cluster report and stops K-grid work when the report becomes active", async () => {
+  test("opens completed results on the quartet tree and stops K-grid work when the tree becomes active", async () => {
     const onOptimizationEnd = vi.fn();
     render(
       <KGridVisualization
@@ -98,15 +98,17 @@ describe("K-grid visualization lifecycle", () => {
       />,
     );
 
-    expect(screen.getByRole("button", {name: "Cluster report"})).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("heading", {name: "Suggested structure"})).toBeInTheDocument();
+    expect(screen.getByRole("button", {name: "Quartet tree"})).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", {name: "Cluster report"})).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText("Quartet result")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", {name: "Suggested structure"})).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", {name: "K-grid"}));
     fireEvent.click(screen.getByRole("button", {name: "Start mock K-grid"}));
-    fireEvent.click(screen.getByRole("button", {name: "Cluster report"}));
+    fireEvent.click(screen.getByRole("button", {name: "Quartet tree"}));
 
     await waitFor(() => expect(onOptimizationEnd).toHaveBeenCalledTimes(1));
-    expect(screen.getByRole("button", {name: "Cluster report"})).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", {name: "Quartet tree"})).toHaveAttribute("aria-pressed", "true");
     expect(screen.queryByText(/Status:/)).not.toBeInTheDocument();
     expect(screen.queryByText("ncd-pipeline-v3")).not.toBeInTheDocument();
   });

--- a/ncd-calculator/src/components/KGridVisualization.tsx
+++ b/ncd-calculator/src/components/KGridVisualization.tsx
@@ -48,7 +48,7 @@ const KGridVisualization: React.FC<KGridVisualizationProps> = ({
                                                                    errorMsg
                                                                }) => {
     // State management
-    const [activeViz, setActiveViz] = useState<VisualizationTypeValue>(VisualizationType.REPORT);
+    const [activeViz, setActiveViz] = useState<VisualizationTypeValue>(VisualizationType.QUARTET);
     const [selectedTheme, setSelectedTheme] = useState("scientific");
     const [isRunning, setIsRunning] = useState(false);
     const [showHelp, setShowHelp] = useState(false);


### PR DESCRIPTION
## What changed

- Open completed NCD results on the quartet-tree visualization by default.
- Keep the Explainable Cluster Report available as a secondary result tab.
- Update the visualization lifecycle test to assert the tree is selected and rendered first, and that returning to it stops active K-grid work.

## Why

The Explainable Cluster Report integration changed the initial visualization state from the quartet tree to the report. The quartet tree is the primary inferred topology and should remain the first visualization shown after the NCD and QSearch pipeline completes.

## User impact

Users see the inferred quartet topology immediately. They can still select Cluster report, K-grid, or Distance matrix without losing any functionality.

## Validation

- Focused lifecycle test: 3 passed.
- Fast project suite excluding the existing large-file compression-worker test: 40 files, 257 tests passed.
- Production build and bundle verification passed.
- Repository-wide TypeScript checking remains red on pre-existing errors in main; no reported error is in this change.
