### PR TITLE
Add anonymous principals for login-free usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The calculator includes a locally bundled, integrity-checked GRS 1915+105 RXTE t
 
 Completed clustering experiments can be downloaded as versioned JSON containing the exact inputs, compression records, NCD matrices, quartet topology, search metadata, and integrity hashes. See [`ncd-calculator/docs/CLUSTERING_EXPERIMENT_EXPORT.md`](ncd-calculator/docs/CLUSTERING_EXPERIMENT_EXPORT.md).
 
+Calculator use does not require an account. A first-party anonymous principal records activated browser installations and completed calculations without accepting filenames, labels, scientific contents, fingerprints, or IP-derived identifiers. The same principal can own a future cloud workspace and later be claimed by a recoverable account. The identity model, API, metrics semantics, security controls, retention, and operational procedure are documented in [`ncd-calculator/docs/ANONYMOUS_PRINCIPALS.md`](ncd-calculator/docs/ANONYMOUS_PRINCIPALS.md).
+
 ### Development environment
 ##### Configure NCBI E-utilities
 1. Go to: https://account.ncbi.nlm.nih.gov/settings/ > *Account Settings*
@@ -69,6 +71,10 @@ NCBI_EMAIL=<MAINTAINER_EMAIL>
 FRONTEND_BASE_URL=<FRONTEND_BASE_URL> (i.e. https://openscienceresearchpark.com)
 BASE_URL=<BACKEND_BASE_URL> (i.e. https://openscienceresearchpark.com/api)
 PORT=3001
+
+# Random value with at least 32 characters. When omitted, the internal
+# anonymous aggregate-metrics endpoint is unavailable.
+ANONYMOUS_METRICS_TOKEN=<RANDOM_METRICS_TOKEN>
 ```
 
 The API key is kept on the backend and must not be exposed through a `VITE_` variable. NCBI permits one API key per account. Without a key, the backend automatically uses the documented three-request-per-second limit; with a key it uses ten requests per second. `NCBI_EMAIL` identifies the maintainer to NCBI for operational contact.

--- a/complearn-genbank/__tests__/anonymousPrincipal.test.ts
+++ b/complearn-genbank/__tests__/anonymousPrincipal.test.ts
@@ -1,0 +1,243 @@
+import crypto from "crypto";
+import http from "http";
+import {AddressInfo} from "net";
+import express from "express";
+import {sequelize} from "../configurations/databaseConnection";
+import {AnonymousActivityDay} from "../models/anonymousActivityDay";
+import {AnonymousCalculationEvent} from "../models/anonymousCalculationEvent";
+import {AnonymousPrincipal} from "../models/anonymousPrincipal";
+import {createAnonymousRouter} from "../routes/anonymous";
+import {
+    ANONYMOUS_COOKIE_NAME,
+    hashAnonymousCredential,
+} from "../services/anonymousPrincipalService";
+
+jest.mock("../configurations/logger", () => ({
+    __esModule: true,
+    default: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const METRICS_TOKEN = "test-metrics-token-with-at-least-32-characters";
+
+let server: http.Server;
+let baseUrl: string;
+
+const postJson = async (
+    path: string,
+    body: object | undefined,
+    headers: Record<string, string> = {},
+): Promise<Response> => fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+        ...(body ? {"Content-Type": "application/json"} : {}),
+        ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+});
+
+const extractCookiePair = (response: Response): string => {
+    const setCookie = response.headers.get("set-cookie");
+    if (!setCookie) throw new Error("Expected the response to set an anonymous credential cookie");
+    return setCookie.split(";", 1)[0];
+};
+
+beforeAll(async () => {
+    const testApp = express();
+    testApp.use(express.json());
+    testApp.use("/api/anonymous", createAnonymousRouter({
+        isProduction: false,
+        metricsToken: METRICS_TOKEN,
+    }));
+    server = http.createServer(testApp);
+    await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+beforeEach(async () => {
+    await sequelize.sync({force: true});
+});
+
+afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    await sequelize.close();
+});
+
+describe("anonymous principal API", () => {
+    test("issues an opaque credential and reuses the same principal", async () => {
+        const firstResponse = await postJson("/api/anonymous/session", undefined);
+        expect(firstResponse.status).toBe(201);
+        expect(await firstResponse.json()).toEqual({ready: true, created: true});
+        const setCookie = firstResponse.headers.get("set-cookie") ?? "";
+        expect(setCookie).toContain(`${ANONYMOUS_COOKIE_NAME}=`);
+        expect(setCookie).toContain("HttpOnly");
+        expect(setCookie).toContain("SameSite=Lax");
+        expect(setCookie).toContain("Path=/");
+
+        const cookiePair = extractCookiePair(firstResponse);
+        const rawCredential = cookiePair.slice(cookiePair.indexOf("=") + 1);
+        const storedPrincipal = await AnonymousPrincipal.findOne();
+        expect(storedPrincipal).not.toBeNull();
+        expect(storedPrincipal?.credentialHash).toBe(hashAnonymousCredential(rawCredential));
+        expect(storedPrincipal?.credentialHash).not.toContain(rawCredential);
+
+        const repeatedResponse = await postJson(
+            "/api/anonymous/session",
+            undefined,
+            {Cookie: cookiePair},
+        );
+        expect(repeatedResponse.status).toBe(200);
+        expect(await repeatedResponse.json()).toEqual({ready: true, created: false});
+        expect(repeatedResponse.headers.get("set-cookie")).toBeNull();
+        expect(await AnonymousPrincipal.count()).toBe(1);
+
+        await storedPrincipal?.update({credentialExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)});
+        const renewalResponse = await postJson(
+            "/api/anonymous/session",
+            undefined,
+            {Cookie: cookiePair},
+        );
+        expect(renewalResponse.status).toBe(200);
+        expect(renewalResponse.headers.get("set-cookie")).toContain(`${ANONYMOUS_COOKIE_NAME}=`);
+        expect(await AnonymousPrincipal.count()).toBe(1);
+    });
+
+    test("records idempotent start and completion activity without accepting arbitrary metadata", async () => {
+        const runId = crypto.randomUUID();
+        const startedEvent = {
+            eventId: crypto.randomUUID(),
+            runId,
+            eventType: "calculation_started",
+            inputKind: "objects",
+            objectCount: 4,
+        };
+        const startedResponse = await postJson("/api/anonymous/events", startedEvent);
+        expect(startedResponse.status).toBe(202);
+        expect(await startedResponse.json()).toEqual({accepted: true, duplicate: false});
+        const cookiePair = extractCookiePair(startedResponse);
+
+        const duplicateResponse = await postJson(
+            "/api/anonymous/events",
+            startedEvent,
+            {Cookie: cookiePair},
+        );
+        expect(duplicateResponse.status).toBe(200);
+        expect(await duplicateResponse.json()).toEqual({accepted: true, duplicate: true});
+
+        const conflictingResponse = await postJson(
+            "/api/anonymous/events",
+            {...startedEvent, objectCount: 5},
+            {Cookie: cookiePair},
+        );
+        expect(conflictingResponse.status).toBe(409);
+
+        const completedResponse = await postJson(
+            "/api/anonymous/events",
+            {
+                ...startedEvent,
+                eventId: crypto.randomUUID(),
+                eventType: "calculation_completed",
+            },
+            {Cookie: cookiePair},
+        );
+        expect(completedResponse.status).toBe(202);
+
+        const principal = await AnonymousPrincipal.findOne();
+        const activityDay = await AnonymousActivityDay.findOne();
+        expect(principal?.activatedAt).toBeInstanceOf(Date);
+        expect(principal?.firstCompletedAt).toBeInstanceOf(Date);
+        expect(activityDay?.calculationStartedCount).toBe(1);
+        expect(activityDay?.calculationCompletedCount).toBe(1);
+        expect(await AnonymousCalculationEvent.count()).toBe(2);
+
+        const rejectedResponse = await postJson("/api/anonymous/events", {
+            ...startedEvent,
+            eventId: crypto.randomUUID(),
+            contents: "research data must never enter anonymous telemetry",
+        });
+        expect(rejectedResponse.status).toBe(400);
+        expect(await AnonymousPrincipal.count()).toBe(1);
+    });
+
+    test("reports installation semantics through a bearer-protected aggregate endpoint", async () => {
+        const runId = crypto.randomUUID();
+        const startResponse = await postJson("/api/anonymous/events", {
+            eventId: crypto.randomUUID(),
+            runId,
+            eventType: "calculation_started",
+            inputKind: "distance-matrix",
+            objectCount: 8,
+        });
+        const cookiePair = extractCookiePair(startResponse);
+        await postJson("/api/anonymous/events", {
+            eventId: crypto.randomUUID(),
+            runId,
+            eventType: "calculation_completed",
+            inputKind: "distance-matrix",
+            objectCount: 8,
+        }, {Cookie: cookiePair});
+
+        const unauthorized = await fetch(`${baseUrl}/api/anonymous/metrics`);
+        expect(unauthorized.status).toBe(401);
+
+        const response = await fetch(`${baseUrl}/api/anonymous/metrics`, {
+            headers: {Authorization: `Bearer ${METRICS_TOKEN}`},
+        });
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+            semantics: "anonymous-browser-installations",
+            totals: {
+                issuedInstallations: 1,
+                activatedInstallations: 1,
+                completedInstallations: 1,
+                calculationStarts: 1,
+                calculationCompletions: 1,
+            },
+            last30Days: {activeInstallations: 1},
+        });
+    });
+
+    test("rejects explicit cross-site writes before creating a principal", async () => {
+        const response = await postJson(
+            "/api/anonymous/session",
+            undefined,
+            {"Sec-Fetch-Site": "cross-site"},
+        );
+        expect(response.status).toBe(403);
+        expect(await AnonymousPrincipal.count()).toBe(0);
+    });
+
+    test("uses a host-only secure cookie in production", async () => {
+        const productionApp = express();
+        productionApp.use(express.json());
+        productionApp.use("/api/anonymous", createAnonymousRouter({
+            isProduction: true,
+            metricsToken: METRICS_TOKEN,
+        }));
+        const productionServer = http.createServer(productionApp);
+        await new Promise<void>((resolve, reject) => {
+            productionServer.once("error", reject);
+            productionServer.listen(0, "127.0.0.1", () => resolve());
+        });
+        try {
+            const address = productionServer.address() as AddressInfo;
+            const response = await fetch(`http://127.0.0.1:${address.port}/api/anonymous/session`, {method: "POST"});
+            const setCookie = response.headers.get("set-cookie") ?? "";
+            expect(setCookie).toContain("__Host-complearn_anonymous=");
+            expect(setCookie).toContain("Secure");
+            expect(setCookie).toContain("HttpOnly");
+            expect(setCookie).not.toContain("Domain=");
+        } finally {
+            await new Promise<void>((resolve, reject) => (
+                productionServer.close(error => error ? reject(error) : resolve())
+            ));
+        }
+    });
+});

--- a/complearn-genbank/app.ts
+++ b/complearn-genbank/app.ts
@@ -10,6 +10,7 @@ import logger from "./configurations/logger";
 // routes
 import loginRoutes from "./routes/login";
 import externalRoutes from "./routes/external";
+import anonymousRoutes from "./routes/anonymous";
 import {upsertUser} from "./services/userService";
 import {requestLogger} from "./middleware/requestLogger";
 import {ExtendedGithubProfile} from "./models/extendedGithubProfile";
@@ -80,6 +81,7 @@ passport.use(new GoogleStrategy({
 // mount routes with parent path
 app.use("/api/auth", loginRoutes(passport));
 app.use("/api/external", externalRoutes);
+app.use("/api/anonymous", anonymousRoutes);
 
 // user = the profile object above strategy
 // After authentication is complete => serializeUser to store in the session, allowing the user to stay logged in

--- a/complearn-genbank/configurations/envLoader.ts
+++ b/complearn-genbank/configurations/envLoader.ts
@@ -31,6 +31,10 @@ const ENV_LOADER = {
     MYSQL_PASSWORD: process.env.MYSQL_PASSWORD || "",
     MYSQL_DATABASE: process.env.MYSQL_DATABASE || "",
 
+    // Protects the internal aggregate anonymous-usage endpoint. The endpoint
+    // remains unavailable when this is unset and requires at least 32 bytes.
+    ANONYMOUS_METRICS_TOKEN: process.env.ANONYMOUS_METRICS_TOKEN || "",
+
     NODE_ENV: process.env.NODE_ENV || ""
 };
 

--- a/complearn-genbank/models/anonymousActivityDay.ts
+++ b/complearn-genbank/models/anonymousActivityDay.ts
@@ -1,0 +1,77 @@
+import {DataTypes, Model, Optional} from "sequelize";
+import {sequelize} from "../configurations/databaseConnection";
+
+export interface AnonymousActivityDayAttributes {
+    principalId: string;
+    activityDate: string;
+    calculationStartedCount: number;
+    calculationCompletedCount: number;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+type AnonymousActivityDayCreationAttributes = Optional<
+    AnonymousActivityDayAttributes,
+    "calculationStartedCount" | "calculationCompletedCount" | "createdAt" | "updatedAt"
+>;
+
+export class AnonymousActivityDay
+    extends Model<AnonymousActivityDayAttributes, AnonymousActivityDayCreationAttributes>
+    implements AnonymousActivityDayAttributes {
+    declare principalId: string;
+    declare activityDate: string;
+    declare calculationStartedCount: number;
+    declare calculationCompletedCount: number;
+    declare createdAt: Date;
+    declare updatedAt: Date;
+}
+
+AnonymousActivityDay.init(
+    {
+        principalId: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            primaryKey: true,
+            field: "principal_id",
+            references: {model: "anonymous_principals", key: "id"},
+            onDelete: "CASCADE",
+        },
+        activityDate: {
+            type: DataTypes.DATEONLY,
+            allowNull: false,
+            primaryKey: true,
+            field: "activity_date",
+        },
+        calculationStartedCount: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+            field: "calculation_started_count",
+        },
+        calculationCompletedCount: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+            field: "calculation_completed_count",
+        },
+        createdAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            field: "created_at",
+        },
+        updatedAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            field: "updated_at",
+        },
+    },
+    {
+        sequelize,
+        modelName: "AnonymousActivityDay",
+        tableName: "anonymous_activity_days",
+        timestamps: true,
+        indexes: [
+            {fields: ["activity_date", "principal_id"]},
+        ],
+    },
+);

--- a/complearn-genbank/models/anonymousCalculationEvent.ts
+++ b/complearn-genbank/models/anonymousCalculationEvent.ts
@@ -1,0 +1,105 @@
+import {DataTypes, Model} from "sequelize";
+import {sequelize} from "../configurations/databaseConnection";
+
+// A string table reference avoids an import cycle between Sequelize model files.
+const AnonymousPrincipalTableName = "anonymous_principals";
+
+export const ANONYMOUS_CALCULATION_EVENT_TYPES = [
+    "calculation_started",
+    "calculation_completed",
+] as const;
+
+export type AnonymousCalculationEventType = typeof ANONYMOUS_CALCULATION_EVENT_TYPES[number];
+export type AnonymousCalculationInputKind = "objects" | "distance-matrix";
+
+export interface AnonymousCalculationEventAttributes {
+    id: string;
+    principalId: string;
+    runId: string;
+    eventType: AnonymousCalculationEventType;
+    inputKind: AnonymousCalculationInputKind;
+    objectCount: number;
+    occurredAt: Date;
+}
+
+export class AnonymousCalculationEvent
+    extends Model<AnonymousCalculationEventAttributes>
+    implements AnonymousCalculationEventAttributes {
+    declare id: string;
+    declare principalId: string;
+    declare runId: string;
+    declare eventType: AnonymousCalculationEventType;
+    declare inputKind: AnonymousCalculationInputKind;
+    declare objectCount: number;
+    declare occurredAt: Date;
+}
+
+AnonymousCalculationEvent.init(
+    {
+        id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            primaryKey: true,
+        },
+        principalId: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            field: "principal_id",
+            references: {model: AnonymousPrincipalTableName, key: "id"},
+            onDelete: "CASCADE",
+        },
+        runId: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            field: "run_id",
+        },
+        eventType: {
+            type: DataTypes.STRING(32),
+            allowNull: false,
+            field: "event_type",
+        },
+        inputKind: {
+            type: DataTypes.STRING(32),
+            allowNull: false,
+            field: "input_kind",
+        },
+        objectCount: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            field: "object_count",
+        },
+        occurredAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            field: "occurred_at",
+        },
+    },
+    {
+        sequelize,
+        modelName: "AnonymousCalculationEvent",
+        tableName: "anonymous_calculation_events",
+        timestamps: false,
+        indexes: [
+            {
+                unique: true,
+                fields: ["principal_id", "run_id", "event_type"],
+                name: "anonymous_event_principal_run_type_unique",
+            },
+            {fields: ["event_type", "occurred_at"]},
+        ],
+        validate: {
+            eventTypeIsAllowed(this: AnonymousCalculationEvent): void {
+                const eventType = this.eventType;
+                if (!ANONYMOUS_CALCULATION_EVENT_TYPES.includes(eventType)) {
+                    throw new Error("Unsupported anonymous calculation event type");
+                }
+            },
+            inputKindIsAllowed(this: AnonymousCalculationEvent): void {
+                const inputKind = this.inputKind;
+                if (inputKind !== "objects" && inputKind !== "distance-matrix") {
+                    throw new Error("Unsupported anonymous calculation input kind");
+                }
+            },
+        },
+    },
+);

--- a/complearn-genbank/models/anonymousPrincipal.ts
+++ b/complearn-genbank/models/anonymousPrincipal.ts
@@ -1,0 +1,88 @@
+import {DataTypes, Model, Optional} from "sequelize";
+import {sequelize} from "../configurations/databaseConnection";
+
+export interface AnonymousPrincipalAttributes {
+    id: string;
+    credentialHash: string | null;
+    credentialExpiresAt: Date | null;
+    activatedAt: Date | null;
+    firstCompletedAt: Date | null;
+    lastSeenAt: Date;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+type AnonymousPrincipalCreationAttributes = Optional<
+    AnonymousPrincipalAttributes,
+    "activatedAt" | "firstCompletedAt" | "createdAt" | "updatedAt"
+>;
+
+export class AnonymousPrincipal
+    extends Model<AnonymousPrincipalAttributes, AnonymousPrincipalCreationAttributes>
+    implements AnonymousPrincipalAttributes {
+    declare id: string;
+    declare credentialHash: string | null;
+    declare credentialExpiresAt: Date | null;
+    declare activatedAt: Date | null;
+    declare firstCompletedAt: Date | null;
+    declare lastSeenAt: Date;
+    declare createdAt: Date;
+    declare updatedAt: Date;
+}
+
+AnonymousPrincipal.init(
+    {
+        id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            primaryKey: true,
+        },
+        credentialHash: {
+            type: DataTypes.CHAR(64),
+            allowNull: true,
+            unique: true,
+            field: "credential_hash",
+        },
+        credentialExpiresAt: {
+            type: DataTypes.DATE,
+            allowNull: true,
+            field: "credential_expires_at",
+        },
+        activatedAt: {
+            type: DataTypes.DATE,
+            allowNull: true,
+            field: "activated_at",
+        },
+        firstCompletedAt: {
+            type: DataTypes.DATE,
+            allowNull: true,
+            field: "first_completed_at",
+        },
+        lastSeenAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            field: "last_seen_at",
+        },
+        createdAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            field: "created_at",
+        },
+        updatedAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            field: "updated_at",
+        },
+    },
+    {
+        sequelize,
+        modelName: "AnonymousPrincipal",
+        tableName: "anonymous_principals",
+        timestamps: true,
+        indexes: [
+            {fields: ["activated_at"]},
+            {fields: ["first_completed_at"]},
+            {fields: ["credential_expires_at"]},
+        ],
+    },
+);

--- a/complearn-genbank/routes/anonymous.ts
+++ b/complearn-genbank/routes/anonymous.ts
@@ -1,0 +1,152 @@
+import crypto from "crypto";
+import {Request, Response, Router} from "express";
+import {validate as validateUuid} from "uuid";
+import ENV_LOADER from "../configurations/envLoader";
+import logger from "../configurations/logger";
+import {
+    AnonymousEventConflictError,
+    ANONYMOUS_COOKIE_MAX_AGE_MS,
+    ensureAnonymousPrincipal,
+    getAnonymousCookieName,
+    getAnonymousUsageSummary,
+    recordAnonymousCalculationEvent,
+    RecordAnonymousCalculationEventInput,
+} from "../services/anonymousPrincipalService";
+
+const EVENT_BODY_FIELDS = new Set(["eventId", "runId", "eventType", "inputKind", "objectCount"]);
+
+const configuredFrontendOrigin = (() => {
+    if (!ENV_LOADER.FRONTEND_BASE_URL) return "";
+    try {
+        return new URL(ENV_LOADER.FRONTEND_BASE_URL).origin;
+    } catch {
+        return ENV_LOADER.FRONTEND_BASE_URL;
+    }
+})();
+
+interface AnonymousRouterOptions {
+    isProduction?: boolean;
+    metricsToken?: string;
+}
+
+const setCredentialCookie = (
+    response: Response,
+    cookieName: string,
+    rawCredential: string,
+    isProduction: boolean,
+): void => {
+    response.cookie(cookieName, rawCredential, {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: "lax",
+        path: "/",
+        maxAge: ANONYMOUS_COOKIE_MAX_AGE_MS,
+    });
+};
+
+const rejectCrossSiteWrite = (request: Request, response: Response): boolean => {
+    if (request.get("Sec-Fetch-Site") === "cross-site") {
+        response.status(403).json({error: "Cross-site requests are not allowed"});
+        return true;
+    }
+    const origin = request.get("Origin");
+    if (origin && configuredFrontendOrigin && origin !== configuredFrontendOrigin) {
+        response.status(403).json({error: "Request origin is not allowed"});
+        return true;
+    }
+    return false;
+};
+
+const parseEventBody = (body: unknown): RecordAnonymousCalculationEventInput | null => {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+    const input = body as Record<string, unknown>;
+    if (Object.keys(input).some(field => !EVENT_BODY_FIELDS.has(field))) return null;
+    if (Object.keys(input).length !== EVENT_BODY_FIELDS.size) return null;
+    if (typeof input.eventId !== "string" || !validateUuid(input.eventId)) return null;
+    if (typeof input.runId !== "string" || !validateUuid(input.runId)) return null;
+    if (input.eventType !== "calculation_started" && input.eventType !== "calculation_completed") return null;
+    if (input.inputKind !== "objects" && input.inputKind !== "distance-matrix") return null;
+    if (!Number.isSafeInteger(input.objectCount) || Number(input.objectCount) < 4 || Number(input.objectCount) > 10_000) {
+        return null;
+    }
+    return {
+        eventId: input.eventId,
+        runId: input.runId,
+        eventType: input.eventType,
+        inputKind: input.inputKind,
+        objectCount: Number(input.objectCount),
+    };
+};
+
+export const isMetricsRequestAuthorized = (authorization: string | undefined, expectedToken: string): boolean => {
+    const expected = Buffer.from(expectedToken, "utf8");
+    if (expected.length < 32 || !authorization?.startsWith("Bearer ")) return false;
+    const suppliedToken = authorization.slice("Bearer ".length);
+    const supplied = Buffer.from(suppliedToken, "utf8");
+    return supplied.length === expected.length && crypto.timingSafeEqual(supplied, expected);
+};
+
+export const createAnonymousRouter = (options: AnonymousRouterOptions = {}): Router => {
+    const router = Router();
+    const isProduction = options.isProduction ?? ENV_LOADER.NODE_ENV === "production";
+    const cookieName = getAnonymousCookieName(isProduction);
+    const metricsToken = options.metricsToken ?? ENV_LOADER.ANONYMOUS_METRICS_TOKEN;
+
+    router.post("/session", async (request: Request, response: Response) => {
+        if (rejectCrossSiteWrite(request, response)) return;
+        try {
+            const ensured = await ensureAnonymousPrincipal(request.headers.cookie, cookieName);
+            if (ensured.rawCredential) {
+                setCredentialCookie(response, cookieName, ensured.rawCredential, isProduction);
+            }
+            response.setHeader("Cache-Control", "no-store");
+            response.status(ensured.created ? 201 : 200).json({ready: true, created: ensured.created});
+        } catch (error) {
+            logger.error({requestId: request.requestId, message: "Unable to create anonymous session", error});
+            response.status(503).json({error: "Anonymous session is temporarily unavailable"});
+        }
+    });
+
+    router.post("/events", async (request: Request, response: Response) => {
+        if (rejectCrossSiteWrite(request, response)) return;
+        const event = parseEventBody(request.body);
+        if (!event) {
+            response.status(400).json({error: "Invalid anonymous calculation event"});
+            return;
+        }
+        try {
+            const ensured = await ensureAnonymousPrincipal(request.headers.cookie, cookieName);
+            if (ensured.rawCredential) {
+                setCredentialCookie(response, cookieName, ensured.rawCredential, isProduction);
+            }
+            const result = await recordAnonymousCalculationEvent(ensured.principal, event);
+            response.setHeader("Cache-Control", "no-store");
+            response.status(result.recorded ? 202 : 200).json({accepted: true, duplicate: !result.recorded});
+        } catch (error) {
+            if (error instanceof AnonymousEventConflictError) {
+                response.status(409).json({error: error.message});
+                return;
+            }
+            logger.error({requestId: request.requestId, message: "Unable to record anonymous activity", error});
+            response.status(503).json({error: "Anonymous activity is temporarily unavailable"});
+        }
+    });
+
+    router.get("/metrics", async (request: Request, response: Response) => {
+        if (!isMetricsRequestAuthorized(request.get("Authorization"), metricsToken)) {
+            response.status(metricsToken ? 401 : 404).json({error: "Not found"});
+            return;
+        }
+        try {
+            response.setHeader("Cache-Control", "no-store");
+            response.json(await getAnonymousUsageSummary());
+        } catch (error) {
+            logger.error({requestId: request.requestId, message: "Unable to read anonymous metrics", error});
+            response.status(503).json({error: "Anonymous metrics are temporarily unavailable"});
+        }
+    });
+
+    return router;
+};
+
+export default createAnonymousRouter();

--- a/complearn-genbank/services/anonymousPrincipalService.ts
+++ b/complearn-genbank/services/anonymousPrincipalService.ts
@@ -1,0 +1,250 @@
+import crypto from "crypto";
+import {Op} from "sequelize";
+import {v7 as uuidv7} from "uuid";
+import {sequelize} from "../configurations/databaseConnection";
+import {
+    AnonymousCalculationEvent,
+    AnonymousCalculationEventType,
+    AnonymousCalculationInputKind,
+} from "../models/anonymousCalculationEvent";
+import {AnonymousActivityDay} from "../models/anonymousActivityDay";
+import {AnonymousPrincipal} from "../models/anonymousPrincipal";
+
+export const ANONYMOUS_COOKIE_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000;
+export const ANONYMOUS_COOKIE_RENEWAL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+export const ANONYMOUS_COOKIE_NAME = "complearn_anonymous";
+export const ANONYMOUS_PRODUCTION_COOKIE_NAME = "__Host-complearn_anonymous";
+
+const RAW_CREDENTIAL_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+export interface EnsuredAnonymousPrincipal {
+    principal: AnonymousPrincipal;
+    created: boolean;
+    rawCredential?: string;
+}
+
+export interface RecordAnonymousCalculationEventInput {
+    eventId: string;
+    runId: string;
+    eventType: AnonymousCalculationEventType;
+    inputKind: AnonymousCalculationInputKind;
+    objectCount: number;
+}
+
+export interface AnonymousUsageSummary {
+    semantics: "anonymous-browser-installations";
+    generatedAt: string;
+    windowStart: string;
+    totals: {
+        issuedInstallations: number;
+        activatedInstallations: number;
+        completedInstallations: number;
+        calculationStarts: number;
+        calculationCompletions: number;
+    };
+    last30Days: {
+        activeInstallations: number;
+    };
+}
+
+export class AnonymousEventConflictError extends Error {
+    public constructor() {
+        super("The event identifier is already associated with different calculation data");
+        this.name = "AnonymousEventConflictError";
+    }
+}
+
+export const getAnonymousCookieName = (isProduction: boolean): string => (
+    isProduction ? ANONYMOUS_PRODUCTION_COOKIE_NAME : ANONYMOUS_COOKIE_NAME
+);
+
+export const hashAnonymousCredential = (rawCredential: string): string => (
+    crypto.createHash("sha256").update(rawCredential, "utf8").digest("hex")
+);
+
+export const readCookieValue = (cookieHeader: string | undefined, cookieName: string): string | null => {
+    if (!cookieHeader) return null;
+
+    for (const segment of cookieHeader.split(";")) {
+        const separatorIndex = segment.indexOf("=");
+        if (separatorIndex < 1) continue;
+        const name = segment.slice(0, separatorIndex).trim();
+        if (name !== cookieName) continue;
+        const value = segment.slice(separatorIndex + 1).trim();
+        return RAW_CREDENTIAL_PATTERN.test(value) ? value : null;
+    }
+    return null;
+};
+
+const createAnonymousPrincipal = async (now: Date): Promise<EnsuredAnonymousPrincipal> => {
+    const rawCredential = crypto.randomBytes(32).toString("base64url");
+    const principal = await AnonymousPrincipal.create({
+        id: uuidv7(),
+        credentialHash: hashAnonymousCredential(rawCredential),
+        credentialExpiresAt: new Date(now.getTime() + ANONYMOUS_COOKIE_MAX_AGE_MS),
+        activatedAt: null,
+        firstCompletedAt: null,
+        lastSeenAt: now,
+    });
+
+    return {principal, created: true, rawCredential};
+};
+
+export const ensureAnonymousPrincipal = async (
+    cookieHeader: string | undefined,
+    cookieName: string,
+    now = new Date(),
+): Promise<EnsuredAnonymousPrincipal> => {
+    const rawCredential = readCookieValue(cookieHeader, cookieName);
+    if (!rawCredential) return createAnonymousPrincipal(now);
+
+    const principal = await AnonymousPrincipal.findOne({
+        where: {
+            credentialHash: hashAnonymousCredential(rawCredential),
+            credentialExpiresAt: {[Op.gt]: now},
+        },
+    });
+    if (!principal) return createAnonymousPrincipal(now);
+
+    const startOfUtcDay = new Date(Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate(),
+    ));
+    const updates: {lastSeenAt?: Date; credentialExpiresAt?: Date} = {};
+    if (principal.lastSeenAt < startOfUtcDay) updates.lastSeenAt = now;
+    if (
+        principal.credentialExpiresAt
+        && principal.credentialExpiresAt.getTime() <= now.getTime() + ANONYMOUS_COOKIE_RENEWAL_WINDOW_MS
+    ) {
+        updates.credentialExpiresAt = new Date(now.getTime() + ANONYMOUS_COOKIE_MAX_AGE_MS);
+    }
+    if (Object.keys(updates).length > 0) await principal.update(updates);
+    return {
+        principal,
+        created: false,
+        rawCredential: updates.credentialExpiresAt ? rawCredential : undefined,
+    };
+};
+
+const eventMatches = (
+    event: AnonymousCalculationEvent,
+    principalId: string,
+    input: RecordAnonymousCalculationEventInput,
+): boolean => (
+    event.principalId === principalId
+    && event.runId === input.runId
+    && event.eventType === input.eventType
+    && event.inputKind === input.inputKind
+    && event.objectCount === input.objectCount
+);
+
+export const recordAnonymousCalculationEvent = async (
+    principal: AnonymousPrincipal,
+    input: RecordAnonymousCalculationEventInput,
+    now = new Date(),
+): Promise<{recorded: boolean}> => sequelize.transaction(async transaction => {
+    const eventWithSameId = await AnonymousCalculationEvent.findByPk(input.eventId, {transaction});
+    if (eventWithSameId) {
+        if (!eventMatches(eventWithSameId, principal.id, input)) throw new AnonymousEventConflictError();
+        return {recorded: false};
+    }
+
+    const [event, created] = await AnonymousCalculationEvent.findOrCreate({
+        where: {
+            principalId: principal.id,
+            runId: input.runId,
+            eventType: input.eventType,
+        },
+        defaults: {
+            id: input.eventId,
+            principalId: principal.id,
+            runId: input.runId,
+            eventType: input.eventType,
+            inputKind: input.inputKind,
+            objectCount: input.objectCount,
+            occurredAt: now,
+        },
+        transaction,
+    });
+    if (!created) {
+        if (!eventMatches(event, principal.id, input)) throw new AnonymousEventConflictError();
+        return {recorded: false};
+    }
+
+    const activityDate = now.toISOString().slice(0, 10);
+    const [activityDay] = await AnonymousActivityDay.findOrCreate({
+        where: {principalId: principal.id, activityDate},
+        defaults: {
+            principalId: principal.id,
+            activityDate,
+            calculationStartedCount: 0,
+            calculationCompletedCount: 0,
+        },
+        transaction,
+    });
+    const countField = input.eventType === "calculation_started"
+        ? "calculationStartedCount"
+        : "calculationCompletedCount";
+    await activityDay.increment(countField, {by: 1, transaction});
+
+    await AnonymousPrincipal.update(
+        {lastSeenAt: now},
+        {where: {id: principal.id}, transaction},
+    );
+    await AnonymousPrincipal.update(
+        {activatedAt: now},
+        {where: {id: principal.id, activatedAt: null}, transaction},
+    );
+    if (input.eventType === "calculation_completed") {
+        await AnonymousPrincipal.update(
+            {firstCompletedAt: now},
+            {where: {id: principal.id, firstCompletedAt: null}, transaction},
+        );
+    }
+
+    return {recorded: true};
+});
+
+const utcDateStringDaysAgo = (now: Date, daysAgo: number): string => {
+    const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    date.setUTCDate(date.getUTCDate() - daysAgo);
+    return date.toISOString().slice(0, 10);
+};
+
+export const getAnonymousUsageSummary = async (now = new Date()): Promise<AnonymousUsageSummary> => {
+    const windowStart = utcDateStringDaysAgo(now, 29);
+    const [
+        issuedInstallations,
+        activatedInstallations,
+        completedInstallations,
+        calculationStarts,
+        calculationCompletions,
+        activeInstallations,
+    ] = await Promise.all([
+        AnonymousPrincipal.count(),
+        AnonymousPrincipal.count({where: {activatedAt: {[Op.not]: null}}}),
+        AnonymousPrincipal.count({where: {firstCompletedAt: {[Op.not]: null}}}),
+        AnonymousActivityDay.sum("calculationStartedCount"),
+        AnonymousActivityDay.sum("calculationCompletedCount"),
+        AnonymousActivityDay.count({
+            distinct: true,
+            col: "principalId",
+            where: {activityDate: {[Op.gte]: windowStart}},
+        }),
+    ]);
+
+    return {
+        semantics: "anonymous-browser-installations",
+        generatedAt: now.toISOString(),
+        windowStart,
+        totals: {
+            issuedInstallations,
+            activatedInstallations,
+            completedInstallations,
+            calculationStarts: Number(calculationStarts ?? 0),
+            calculationCompletions: Number(calculationCompletions ?? 0),
+        },
+        last30Days: {activeInstallations},
+    };
+};

--- a/ncd-calculator/README.md
+++ b/ncd-calculator/README.md
@@ -20,6 +20,8 @@ If Vite reports `504 Outdated Optimize Dep` after dependencies or the Vite confi
 
 The calculator opens directly at its input controls. Choose GenBank, UDHR, or local files as the object source. **Animal example** resolves a version-pinned four-record mitochondrial set from NCBI, **Sequence example** provides a small local interface check, and **Astronomy example** loads a verified 16-object RXTE time-series corpus inspired by the astronomy experiment in *Clustering by Compression*.
 
+No account is required for a calculation, including sets larger than 16 objects. After an input passes validation, the browser reports only a random calculation identifier, input kind, object count, and start/completion state to the same-origin backend. The backend maintains a first-party anonymous browser principal for aggregate usage measurement and future opt-in cloud ownership. It never accepts the research inputs through this activity endpoint. See [`docs/ANONYMOUS_PRINCIPALS.md`](docs/ANONYMOUS_PRINCIPALS.md) for exact counting semantics and operations.
+
 1. Add at least four objects, or use the example data.
 2. Choose **Auto-select** or an explicit compressor model.
 3. Select **Show Similarity**. The page reports compression progress and exposes quartet-tree, K-grid, and distance-matrix result views.
@@ -60,6 +62,8 @@ The planar-tree interface reports initialization failures and offers **Retry ren
 
 Focused interface and export coverage is in `src/__test__/landingPage.test.tsx`, `src/__test__/workbench.test.tsx`, and `src/__test__/clusteringExperimentExport.test.ts`.
 
+Anonymous principal client coverage is in `src/__test__/anonymousActivity.test.ts`; the corresponding backend API coverage is in `../complearn-genbank/__tests__/anonymousPrincipal.test.ts`.
+
 ### Reproducible UDHR inputs
 
 UDHR comparisons use a versioned UTF-8 snapshot generated from the Unicode UDHR Project at a pinned commit. Corpus v2 stores all 501 available stage-4 records locally, representing 431 ISO 639-3 language groups. Of those records, 465 link to an OHCHR translation and 36 retain a separate `unicode-complete` provenance tier. The audit accepts 496 records across 426 language codes for aligned comparison; five upstream XML records are preserved but blocked because they do not contain Articles 1–30 in full.
@@ -90,4 +94,4 @@ CompLearn targets WCAG 2.2 Level AA through staged, separately reviewed changes.
 
 The prioritized feature list, 1–10 impact ratings, audit evidence, PR boundaries, and verification policy are maintained in [`docs/ACCESSIBILITY_ROADMAP.md`](docs/ACCESSIBILITY_ROADMAP.md). Each roadmap item is intended to ship in its own PR, with an explicit approval signal before the next item begins.
 
-Updated 2026-08-09 (Asia/Ho_Chi_Minh).
+Updated 2026-08-10 (Asia/Ho_Chi_Minh).

--- a/ncd-calculator/docs/ANONYMOUS_PRINCIPALS.md
+++ b/ncd-calculator/docs/ANONYMOUS_PRINCIPALS.md
@@ -1,0 +1,215 @@
+# Anonymous principals and usage measurement
+
+## Purpose and measurement contract
+
+CompLearn lets a person use the calculator without signing in. The application still needs a durable, server-authorized identity so it can count meaningful product use now and own cloud workspaces later. This implementation calls that identity an **anonymous principal**.
+
+An anonymous principal represents one browser installation that retains its first-party cookie. It does not prove that one human used the browser. The same person on two devices counts as two anonymous installations, a shared browser can represent several people, and clearing site data or using private browsing creates a new installation. Public reports must therefore use names such as **activated anonymous installations**, **monthly active installations**, and **registered accounts**. They must not describe the anonymous count as exact unique humans.
+
+The principal is created only when the browser submits a validated calculation event or explicitly prepares a future cloud session. Merely loading the marketing page does not activate a principal. This keeps crawlers and casual page loads out of the primary product metric.
+
+Implementation updated: 2026-08-10 (Asia/Ho_Chi_Minh).
+
+## Runtime flow
+
+```mermaid
+flowchart LR
+    browser["Browser starts a validated calculation"]
+    api["POST /api/anonymous/events"]
+    identity["Resolve or create anonymous principal"]
+    cookie["Opaque HttpOnly credential cookie"]
+    event["Idempotent calculation event"]
+    day["One aggregate activity row per UTC day"]
+    metrics["Bearer-protected aggregate metrics"]
+
+    browser --> api
+    api --> identity
+    identity --> cookie
+    identity --> event
+    event --> day
+    day --> metrics
+```
+
+The frontend creates a random calculation `runId` and sends one `calculation_started` event after the input has passed validation. It sends `calculation_completed` only after QSearch returns a valid tree. Anonymous reporting is deliberately fail-open: a network or metrics failure is logged in the browser but never makes a local scientific calculation fail.
+
+The backend validates an exact allowlist of five event fields. Labels, filenames, sequence data, uploaded contents, NCD matrices, content hashes, browser fingerprints, IP addresses, referrers, and arbitrary metadata are not accepted by the anonymous event endpoint.
+
+## Credential design
+
+When no valid credential exists, the backend generates:
+
+- a UUIDv7 principal identifier, used only on the server and in database relations;
+- 32 cryptographically random bytes encoded as a base64url credential; and
+- a SHA-256 hash of that credential for database lookup.
+
+Only the hash is stored in MySQL. The raw credential is returned in a first-party cookie. Production uses:
+
+```text
+__Host-complearn_anonymous=<opaque 256-bit credential>
+Path=/; Max-Age=31536000; Secure; HttpOnly; SameSite=Lax
+```
+
+The `__Host-` prefix prevents a `Domain` attribute and requires HTTPS, `HttpOnly` keeps ordinary JavaScript from reading the credential, and `SameSite=Lax` prevents the credential from accompanying ordinary cross-site subrequests. The API additionally rejects requests explicitly marked `Sec-Fetch-Site: cross-site` and rejects a supplied `Origin` that differs from `FRONTEND_BASE_URL`.
+
+Development and tests use `complearn_anonymous` without `Secure` so local HTTP works. Production and development cookie namespaces intentionally differ.
+
+Credentials last one year. An active credential is renewed only when it has fewer than 30 days remaining, avoiding a database and `Set-Cookie` write on every calculation. Expired, malformed, unknown, or revoked credentials create a new principal. A credential is a bearer secret and must never be logged, placed in a URL, exposed to an analytics vendor, or used outside HTTPS production traffic.
+
+## Database tables
+
+### `anonymous_principals`
+
+This is the authoritative installation registry.
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Server-side UUIDv7 principal ID |
+| `credential_hash` | SHA-256 credential hash; nullable after expiry cleanup |
+| `credential_expires_at` | Server-side credential expiry |
+| `activated_at` | First accepted calculation start or completion |
+| `first_completed_at` | First accepted completed calculation |
+| `last_seen_at` | Last observed activity, updated at most once per UTC day outside events |
+| `created_at`, `updated_at` | Database record timestamps |
+
+The count of rows with `activated_at IS NOT NULL` is the all-time activated-installation count. The count with `first_completed_at IS NOT NULL` is the all-time completed-installation count. These queries avoid an expensive all-time `COUNT(DISTINCT event.principal_id)`.
+
+### `anonymous_calculation_events`
+
+This append-only table contains only `id`, `principal_id`, `run_id`, `event_type`, `input_kind`, `object_count`, and the server-controlled `occurred_at`. The unique constraint on `(principal_id, run_id, event_type)` makes browser retries idempotent. Reusing an event ID or run/type tuple with different data returns HTTP `409` rather than silently modifying the original observation.
+
+### `anonymous_activity_days`
+
+The composite primary key `(principal_id, activity_date)` permits at most one row per installation per UTC date. The row contains calculation-start and calculation-completion counters. Monthly active installations are therefore counted from a compact daily table rather than the raw event stream.
+
+The models are in `complearn-genbank/models`, and the existing production startup calls `sequelize.sync()`. Because these are new tables, startup creates them without altering the existing user tables. Future changes to deployed table shapes should use explicit versioned migrations rather than relying on schema alteration at startup.
+
+## HTTP API
+
+### `POST /api/anonymous/session`
+
+Creates or resumes an anonymous principal without activating it. This is intended for a future cloud-save flow that needs an owner before the first calculation event.
+
+- `201 {"ready":true,"created":true}`: new principal and cookie.
+- `200 {"ready":true,"created":false}`: existing principal.
+- `403`: explicit cross-site request.
+- `503`: database or identity service unavailable.
+
+### `POST /api/anonymous/events`
+
+The only accepted request body is:
+
+```json
+{
+  "eventId": "79ce4c3c-8408-4d56-90b1-0a15a94b5814",
+  "runId": "dc034a6a-a564-43a3-b35e-b2e1a1e749ae",
+  "eventType": "calculation_started",
+  "inputKind": "objects",
+  "objectCount": 4
+}
+```
+
+`eventType` is `calculation_started` or `calculation_completed`; `inputKind` is `objects` or `distance-matrix`; and `objectCount` is an integer from 4 through 10,000. Unknown and missing fields are rejected.
+
+- `202 {"accepted":true,"duplicate":false}`: recorded.
+- `200 {"accepted":true,"duplicate":true}`: idempotent retry.
+- `400`: malformed or disallowed event.
+- `403`: explicit cross-site request.
+- `409`: identifier conflict.
+- `503`: persistence unavailable.
+
+### `GET /api/anonymous/metrics`
+
+This endpoint is unavailable when `ANONYMOUS_METRICS_TOKEN` is unset. The configured token must contain at least 32 bytes of random ASCII data and is compared in constant time. Send it only in the authorization header:
+
+```bash
+curl \
+  -H "Authorization: Bearer ${ANONYMOUS_METRICS_TOKEN}" \
+  https://openscienceresearchpark.com/api/anonymous/metrics
+```
+
+The response reports its semantics explicitly:
+
+```json
+{
+  "semantics": "anonymous-browser-installations",
+  "generatedAt": "2026-08-10T00:00:00.000Z",
+  "windowStart": "2026-07-12",
+  "totals": {
+    "issuedInstallations": 1200,
+    "activatedInstallations": 760,
+    "completedInstallations": 610,
+    "calculationStarts": 2400,
+    "calculationCompletions": 1900
+  },
+  "last30Days": {
+    "activeInstallations": 280
+  }
+}
+```
+
+`windowStart` and activity dates use UTC. The 30-day window includes today and the preceding 29 UTC dates.
+
+## Deployment and operations
+
+Set a randomly generated metrics token in `complearn-genbank/.env.production` or the deployment secret manager:
+
+```text
+ANONYMOUS_METRICS_TOKEN=<at-least-32-random-characters>
+```
+
+The frontend and API should remain same-origin in production, as the current `/api` routing already supports. Confirm HTTPS before release and verify that the production response uses `__Host-complearn_anonymous`, `Secure`, `HttpOnly`, `SameSite=Lax`, and `Path=/`.
+
+The GitHub Pages build that points at a backend on another registrable domain cannot use this cookie safely: the browser treats that request as cross-site and the API rejects it. Anonymous metrics for that deployment therefore remain fail-open and unrecorded. Put the public calculator and `/api` behind the same site, or proxy the API through the public site, before treating the dashboard as complete product usage.
+
+The edge proxy must rate-limit principal creation and event submission. A suitable starting policy is approximately 10 new session requests per IP per minute with a small burst and a larger limit for idempotent event posts. Rate limiting belongs at the shared reverse proxy or CDN so all API replicas observe the same policy. The application deliberately does not persist an IP-derived identifier.
+
+The cookie and database row are pseudonymous product identifiers, not a claim of legal anonymity. Publish the measurement purpose, retention period, deletion process, and cloud-storage boundary in the product privacy notice, and review the applicable consent or lawful-basis requirements for each deployment jurisdiction. This technical design deliberately avoids making a universal legal-compliance claim.
+
+Back up the three tables with the rest of MySQL. Alert on elevated `503`, `400`, or `409` rates and on an abnormal ratio of issued to activated installations. A sudden rise in issued-but-never-activated principals is usually automation, invalid cookies, or a broken frontend integration.
+
+After a credential has expired, its lookup hash is no longer needed. A scheduled privacy cleanup can remove expired credentials while retaining aggregate principal history:
+
+```sql
+UPDATE anonymous_principals
+SET credential_hash = NULL,
+    credential_expires_at = NULL
+WHERE credential_expires_at < UTC_TIMESTAMP();
+```
+
+Unactivated expired principals may be deleted after the chosen retention period. Activated principals should remain if the product promises an all-time activated-installation metric; otherwise, first preserve the required aggregate and document the retention boundary. Raw calculation events can receive a finite retention period after daily counters and financial reporting requirements are verified.
+
+## Future cloud projects and account claiming
+
+Anonymous identity makes cloud storage possible without a login wall, but it does not provide recovery. A user who loses the cookie cannot recover anonymous work from another device. The cloud feature should therefore use these entities:
+
+```text
+workspaces(id, created_at)
+workspace_principals(workspace_id, principal_id, role)
+projects(id, workspace_id, encrypted_payload, created_at, updated_at)
+workspace_accounts(workspace_id, provider_name, user_login_id, role)
+```
+
+On the first explicit **Save to cloud** action, the server resolves the cookie, creates a workspace and principal membership in one transaction, applies an anonymous storage quota, then stores the project. Scientific input data must never be uploaded merely because usage activity was recorded; cloud upload requires a separate, visible user action and its own privacy explanation.
+
+When the person later signs in, claim the workspace transactionally by adding the authenticated account membership. Keep the anonymous principal relation long enough to make retries safe, but make the account the recoverable owner. If the account already owns a workspace, use a documented merge policy and idempotency key. Do not rewrite historical activity or use an analytics vendor's `distinct_id` as authorization.
+
+Cross-device recovery, collaboration, billing, and deletion requests require a permanent account, passkey, verified email link, or another recoverable authentication method. Anonymous principals remove the initial login wall; they do not eliminate the need for stronger identity when the product begins making durable promises to a user.
+
+## Verification
+
+Backend coverage verifies credential hashing, cookie reuse and renewal, idempotent start/completion events, rejection of arbitrary research metadata, aggregate metrics authorization, and cross-site rejection:
+
+```bash
+cd complearn-genbank
+npm run build
+npm test -- --runInBand __tests__/anonymousPrincipal.test.ts
+```
+
+Frontend coverage verifies the exact allowlisted payload, credentialed requests, explicit session preparation, and fail-open reporting:
+
+```bash
+cd ncd-calculator
+npm run typecheck
+npm test -- src/__test__/anonymousActivity.test.ts
+npm run build
+```

--- a/ncd-calculator/src/App.tsx
+++ b/ncd-calculator/src/App.tsx
@@ -11,7 +11,7 @@ import {RouteAccessibility} from "@/components/RouteAccessibility";
 
 function App() {
     const [openLogin, setOpenLogin] = useState(false)
-    const [authenticated, setAuthenticated] = useState(false)
+    const [, setAuthenticated] = useState(false)
     const closeLogin = useCallback((): void => setOpenLogin(false), []);
 
     return (
@@ -33,7 +33,6 @@ function App() {
                         element={
                             <QSearch
                                 setOpenLogin={setOpenLogin}
-                                authenticated={authenticated}
                                 setAuthenticated={setAuthenticated}
                             />
                         }

--- a/ncd-calculator/src/__test__/anonymousActivity.test.ts
+++ b/ncd-calculator/src/__test__/anonymousActivity.test.ts
@@ -1,0 +1,67 @@
+import {afterEach, describe, expect, test, vi} from "vitest";
+import {
+    createAnonymousCalculationRun,
+    ensureAnonymousSession,
+    recordAnonymousCalculationEvent,
+    trackAnonymousCalculationEvent,
+} from "../services/AnonymousActivity";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+describe("anonymous activity client", () => {
+    test("sends a typed calculation event with credentials and no research content", async () => {
+        const fetchMock = vi.fn(async () => new Response(null, {status: 202}));
+        vi.stubGlobal("fetch", fetchMock);
+        const run = createAnonymousCalculationRun("objects", 4);
+
+        await recordAnonymousCalculationEvent(run, "calculation_started");
+
+        expect(run.runId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, options] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        expect(url).toContain("/api/anonymous/events");
+        expect(options).toMatchObject({
+            method: "POST",
+            credentials: "include",
+            keepalive: true,
+        });
+        const body = JSON.parse(String(options.body)) as Record<string, unknown>;
+        expect(body).toMatchObject({
+            runId: run.runId,
+            eventType: "calculation_started",
+            inputKind: "objects",
+            objectCount: 4,
+        });
+        expect(body.eventId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(Object.keys(body).sort()).toEqual([
+            "eventId",
+            "eventType",
+            "inputKind",
+            "objectCount",
+            "runId",
+        ]);
+    });
+
+    test("can bootstrap a future anonymous cloud workspace explicitly", async () => {
+        const fetchMock = vi.fn(async () => new Response(null, {status: 201}));
+        vi.stubGlobal("fetch", fetchMock);
+
+        await ensureAnonymousSession();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining("/api/anonymous/session"),
+            expect.objectContaining({method: "POST", credentials: "include"}),
+        );
+    });
+
+    test("keeps reporting failures out of the calculation control flow", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(null, {status: 503})));
+        const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+        const run = createAnonymousCalculationRun("distance-matrix", 8);
+
+        expect(() => trackAnonymousCalculationEvent(run, "calculation_started")).not.toThrow();
+        await vi.waitFor(() => expect(warning).toHaveBeenCalledOnce());
+    });
+});

--- a/ncd-calculator/src/__test__/workbench.test.tsx
+++ b/ncd-calculator/src/__test__/workbench.test.tsx
@@ -145,8 +145,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -163,8 +161,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -185,8 +181,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -202,8 +196,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={onComputedNcdInput}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -234,8 +226,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={onComputedNcdInput}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -266,8 +256,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );

--- a/ncd-calculator/src/components/InputHolder.tsx
+++ b/ncd-calculator/src/components/InputHolder.tsx
@@ -7,14 +7,12 @@ export interface InputAccumulatorProps {
   MIN_ITEMS?: number;
   selectedItems: SelectedItem[];
   onRemoveItem: (id: string) => void;
-  authenticated?: boolean;
 }
 
 export const InputHolder: React.FC<InputAccumulatorProps> = ({
   MIN_ITEMS = 4,
   selectedItems,
   onRemoveItem,
-  authenticated,
 }) => {
   const items = Array.isArray(selectedItems) ? selectedItems : [];
   const remainingItems = Math.max(MIN_ITEMS - items.length, 0);
@@ -70,11 +68,6 @@ export const InputHolder: React.FC<InputAccumulatorProps> = ({
             <div className="selected-objects__summary" aria-live="polite">
                 <strong>{items.length} {items.length === 1 ? "object" : "objects"}</strong>
                 {remainingItems > 0 && <span>{remainingItems} more needed</span>}
-                {!authenticated && items.length > 16 && (
-                    <p className="selected-objects__limit" role="alert">
-                        Sign in to prepare a set larger than 16 objects.
-                    </p>
-                )}
             </div>
             <div className="selected-objects__progress" aria-label={`${items.length} of ${MIN_ITEMS} required objects selected`}>
                 <span style={{width: `${Math.min((items.length / MIN_ITEMS) * 100, 100)}%`}} />

--- a/ncd-calculator/src/components/ListEditor.tsx
+++ b/ncd-calculator/src/components/ListEditor.tsx
@@ -115,8 +115,6 @@ interface ListEditorProps {
 	onComputedNcdInput: (input: NCDInput) => void;
 	setIsLoading: (loading: boolean) => void;
 	resetDisplay: () => void;
-	setOpenLogin: (open: boolean) => void;
-	authenticated: boolean;
 	initialSearchMode?: SearchMode | null;
 }
 
@@ -322,10 +320,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	};
 	
 	const sendNcdInput = async (): Promise<void> => {
-		// if (selectedItems && selectedItems.length > 16 && !authenticated) {
-		// 	setOpenLogin(true);
-		// 	return;
-		// }
 		setImportError(null);
 		setIsLoading(true);
 		try {

--- a/ncd-calculator/src/components/QSearch.tsx
+++ b/ncd-calculator/src/components/QSearch.tsx
@@ -39,17 +39,20 @@ import {
 	serializeClusteringExperimentExport,
 } from "@/services/ClusteringExperimentExport";
 import type {ClusteringExperimentTiming, CompleteCompressionRecords} from "@/types/experiment";
+import {
+	createAnonymousCalculationRun,
+	trackAnonymousCalculationEvent,
+} from "@/services/AnonymousActivity";
+import type {AnonymousCalculationRun} from "@/services/AnonymousActivity";
 import "./Workbench.css";
 
 export interface QSearchProps {
 	setOpenLogin: (open: boolean) => void;
-	authenticated: boolean;
 	setAuthenticated: (auth: boolean) => void;
 }
 
 export const QSearch: React.FC<QSearchProps> = ({
 	                                                setOpenLogin,
-	                                                authenticated,
 	                                                setAuthenticated,
 	                                                }) => {
 	const [ncdMatrix, setNcdMatrix] = useState<number[][]>([]);
@@ -69,6 +72,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 	const [compressionRecords, setCompressionRecords] = useState<CompleteCompressionRecords | null>(null);
 	const [experimentTiming, setExperimentTiming] = useState<ClusteringExperimentTiming | null>(null);
 	const experimentStartedAtRef = useRef<string | null>(null);
+	const anonymousCalculationRunRef = useRef<AnonymousCalculationRun | null>(null);
 	
 	// Add gridObjects state for KGridVisualization
 	const [gridObjects, setGridObjects] = useState<GridObject[]>([]);
@@ -111,10 +115,14 @@ export const QSearch: React.FC<QSearchProps> = ({
 				});
 				setQSearchProgress(null);
 				setIsLoading(false);
+				const anonymousRun = anonymousCalculationRunRef.current;
+				anonymousCalculationRunRef.current = null;
+				if (anonymousRun) trackAnonymousCalculationEvent(anonymousRun, "calculation_completed");
 			} catch (error) {
 				console.error("Error processing QSearch result:", error);
 				setErrorMsg("QSearch returned an invalid tree result");
 				setIsLoading(false);
+				anonymousCalculationRunRef.current = null;
 			}
 		} else if (event.data.action === "qsearchProgress") {
 			setQSearchProgress({
@@ -125,6 +133,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 			setErrorMsg(`Tree search failed: ${event.data.message}`);
 			setQSearchProgress(null);
 			setIsLoading(false);
+			anonymousCalculationRunRef.current = null;
 		}
 	};
 	
@@ -160,14 +169,19 @@ export const QSearch: React.FC<QSearchProps> = ({
 			return;
 		}
 		
-		// Check authentication for large computations
-		if (input.contents.length > 16 && !authenticated) {
-			setOpenLogin(true);
-			return;
-		}
-		
 		try {
 			const computationInput: NCDInput = {...input, labels: normalizedLabels};
+			try {
+				const anonymousRun = createAnonymousCalculationRun(
+					computationInput.kind === "distance-matrix" ? "distance-matrix" : "objects",
+					computationInput.contents.length,
+				);
+				anonymousCalculationRunRef.current = anonymousRun;
+				trackAnonymousCalculationEvent(anonymousRun, "calculation_started");
+			} catch {
+				anonymousCalculationRunRef.current = null;
+				console.warn("Anonymous usage activity could not be initialized.");
+			}
 			const startedAt = new Date().toISOString();
 			experimentStartedAtRef.current = startedAt;
 			setCurrentInput(computationInput);
@@ -324,6 +338,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 			console.error("Error in onNcdInput:", error);
 			setErrorMsg(error instanceof Error ? error.message : "Processing failed");
 			setIsLoading(false);
+			anonymousCalculationRunRef.current = null;
 		}
 	};
 
@@ -422,6 +437,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 		setCurrentInput(null);
 		setExperimentTiming(null);
 		experimentStartedAtRef.current = null;
+		anonymousCalculationRunRef.current = null;
 		setCompressionStats({
 			processedPairs: 0,
 			totalPairs: 0,
@@ -445,8 +461,6 @@ export const QSearch: React.FC<QSearchProps> = ({
 					onComputedNcdInput={onNcdInput}
 					setIsLoading={setIsLoading}
 					resetDisplay={resetDisplay}
-					setOpenLogin={setOpenLogin}
-					authenticated={authenticated}
 				/>
 				
 				{isLoading && (

--- a/ncd-calculator/src/services/AnonymousActivity.ts
+++ b/ncd-calculator/src/services/AnonymousActivity.ts
@@ -1,0 +1,69 @@
+import {BACKEND_BASE_URL} from "@/configs/api";
+
+export type AnonymousCalculationInputKind = "objects" | "distance-matrix";
+export type AnonymousCalculationEventType = "calculation_started" | "calculation_completed";
+
+export interface AnonymousCalculationRun {
+    readonly runId: string;
+    readonly inputKind: AnonymousCalculationInputKind;
+    readonly objectCount: number;
+}
+
+interface AnonymousCalculationEvent extends AnonymousCalculationRun {
+    readonly eventId: string;
+    readonly eventType: AnonymousCalculationEventType;
+}
+
+const anonymousApiUrl = (path: string): string => `${BACKEND_BASE_URL}/anonymous/${path}`;
+
+export const createAnonymousCalculationRun = (
+    inputKind: AnonymousCalculationInputKind,
+    objectCount: number,
+): AnonymousCalculationRun => ({
+    runId: globalThis.crypto.randomUUID(),
+    inputKind,
+    objectCount,
+});
+
+const sendJson = async (path: string, body?: object): Promise<Response> => fetch(anonymousApiUrl(path), {
+    method: "POST",
+    credentials: "include",
+    keepalive: true,
+    headers: body ? {"Content-Type": "application/json"} : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+});
+
+/**
+ * Creates or resumes the first-party anonymous principal without exposing its
+ * opaque HttpOnly credential to JavaScript. Future cloud-save calls can use
+ * this before creating a principal-owned workspace.
+ */
+export const ensureAnonymousSession = async (): Promise<void> => {
+    const response = await sendJson("session");
+    if (!response.ok) throw new Error(`Anonymous session request failed with status ${response.status}`);
+};
+export const recordAnonymousCalculationEvent = async (
+    run: AnonymousCalculationRun,
+    eventType: AnonymousCalculationEventType,
+): Promise<void> => {
+    const event: AnonymousCalculationEvent = {
+        ...run,
+        eventId: globalThis.crypto.randomUUID(),
+        eventType,
+    };
+    const response = await sendJson("events", event);
+    if (!response.ok) throw new Error(`Anonymous activity request failed with status ${response.status}`);
+};
+
+/**
+ * Anonymous usage reporting must never make a local scientific calculation
+ * fail. The backend remains authoritative for validation and deduplication.
+ */
+export const trackAnonymousCalculationEvent = (
+    run: AnonymousCalculationRun,
+    eventType: AnonymousCalculationEventType,
+): void => {
+    void recordAnonymousCalculationEvent(run, eventType).catch(() => {
+        console.warn("Anonymous usage activity could not be recorded.");
+    });
+};


### PR DESCRIPTION
## Summary

- add a database-backed anonymous principal identified by a first-party, opaque HttpOnly credential
- record idempotent calculation start/completion events and compact per-day activity aggregates
- expose bearer-protected aggregate metrics with explicit anonymous-browser-installation semantics
- remove the calculator's 16-object login gate and make telemetry fail open
- document security, privacy, deployment, retention, scaling, and future workspace-claim behavior

## Why

The calculator needs a defensible adoption metric and a durable server-authorized owner for future cloud projects without forcing an account at first use. This measures activated browser installations, not unique humans: one person can have several installations, and a shared browser can represent several people.

The event endpoint accepts only random event/run IDs, input kind, object count, and start/completion state. It rejects labels, filenames, scientific inputs, matrices, hashes, and arbitrary metadata.

## Operational impact

- Production must serve the frontend and API from the same site over HTTPS.
- Set a random 32+ byte `ANONYMOUS_METRICS_TOKEN`; the metrics endpoint is unavailable when it is unset.
- Production credentials use a `__Host-` cookie with `Secure`, `HttpOnly`, `SameSite=Lax`, and `Path=/`.
- Apply shared edge/CDN rate limits to principal creation and event submission.
- Cross-site deployments intentionally fail open and will not produce complete usage metrics.
- Existing startup synchronization creates the three new tables; later schema changes should use versioned migrations.

## Validation

- `complearn-genbank: npm run build`
- `complearn-genbank: npm test -- --runInBand` — 25 passed
- `ncd-calculator: npm run lint`
- `ncd-calculator: npm run build`
- `ncd-calculator: npm test` — 266 passed
- `git diff --check origin/main...HEAD`

Known baseline: `ncd-calculator: npm run typecheck` already fails on `main` in unrelated legacy files. The stale login-gate prop found in this PR's workbench test was removed, and the production build plus all tests pass.
