### PR TITLE
Add Google Analytics usage measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ cd ncd-calculator
 2. Create environment variables in .env file:
 ```
 VITE_BACKEND_BASE_URL=<BACKEND-SERVER-DOMAIN> (i.e. https://openscienceresearchpark.com/api)
+VITE_GA_MEASUREMENT_ID=<GA4-WEB-STREAM-ID> (optional, i.e. G-XXXXXXXXXX)
 ```
+
+The GA4 measurement ID is a public build-time identifier, not a secret. When it is unset, analytics is disabled. The frontend reports only coarse calculation start/completion events in addition to GA4's default web measurement; it does not send scientific inputs. See [`ncd-calculator/docs/GOOGLE_ANALYTICS.md`](ncd-calculator/docs/GOOGLE_ANALYTICS.md) for counting semantics, dashboard setup, privacy controls, and deployment requirements.
 3. Running commands
 ```bash
 npm install && npm run dev
@@ -93,5 +96,6 @@ cd ncd-calculator
 VITE_BASE_URL=/ncd/ \
 VITE_BACKEND_BASE_URL=https://openscienceresearchpark.com/api \
 VITE_AUTH_ENABLED=false \
+VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX \
 npm run build
 ```

--- a/ncd-calculator/README.md
+++ b/ncd-calculator/README.md
@@ -20,6 +20,8 @@ If Vite reports `504 Outdated Optimize Dep` after dependencies or the Vite confi
 
 The calculator opens directly at its input controls. Choose GenBank, UDHR, or local files as the object source. **Animal example** resolves a version-pinned four-record mitochondrial set from NCBI, **Sequence example** provides a small local interface check, and **Astronomy example** loads a verified 16-object RXTE time-series corpus inspired by the astronomy experiment in *Clustering by Compression*.
 
+No account is required for a calculation, including sets larger than 16 objects. When `VITE_GA_MEASUREMENT_ID` is configured, GA4 provides approximate browser-user and usage reports without an application analytics database. The calculator sends only calculation start/completion state, input kind, and object count as custom fields; it never sends labels, filenames, scientific contents, matrices, or hashes. See [`docs/GOOGLE_ANALYTICS.md`](docs/GOOGLE_ANALYTICS.md) for the exact measurement contract, dashboard setup, consent boundary, and limitations.
+
 1. Add at least four objects, or use the example data.
 2. Choose **Auto-select** or an explicit compressor model.
 3. Select **Show Similarity**. The page reports compression progress and exposes quartet-tree, K-grid, and distance-matrix result views.
@@ -59,6 +61,8 @@ npm run dev -- --force
 The planar-tree interface reports initialization failures and offers **Retry renderer**. The shared loader deduplicates concurrent initialization and clears failed attempts before retrying. Compression workers use Vite's native `new Worker(new URL(...))` transform rather than dynamically importing `?worker` wrapper modules; `workers:verify-dev` transforms and serves all four entries in middleware mode so development-only worker regressions fail before a build. The selected compressor starts lazily when a calculation begins—there is no competing prewarm—and has a 30-second cold-start window. Native worker load and message-decoding failures are reported immediately and failed workers are terminated.
 
 Focused interface and export coverage is in `src/__test__/landingPage.test.tsx`, `src/__test__/workbench.test.tsx`, and `src/__test__/clusteringExperimentExport.test.ts`.
+
+Google Analytics integration coverage is in `src/__test__/googleAnalytics.test.ts`. Analytics remains disabled when its public GA4 measurement ID is not configured.
 
 ### Reproducible UDHR inputs
 

--- a/ncd-calculator/docs/GOOGLE_ANALYTICS.md
+++ b/ncd-calculator/docs/GOOGLE_ANALYTICS.md
@@ -1,0 +1,122 @@
+# Google Analytics usage measurement
+
+## Purpose and boundary
+
+CompLearn uses Google Analytics 4 (GA4) to measure visits and calculator activation without requiring a login or maintaining an application analytics database. GA4 provides the collection service, approximate distinct-user metrics, standard reports, Realtime, and Explorations.
+
+This measurement is deliberately separate from application authorization. A GA client ID cannot own a cloud project, enforce a quota, recover work on another device, or be trusted as a server credential. A future cloud-save feature will still require a server-authorized anonymous principal, an account, or another recoverable identity. The GA client ID must never be accepted by the backend as proof of ownership.
+
+Implementation updated: 2026-08-10 (Asia/Ho_Chi_Minh).
+
+## Counting semantics
+
+The Google tag stores a random client ID in the first-party `_ga` cookie when analytics storage is granted. GA4 uses that device/browser identifier to calculate user metrics. CompLearn does not create or send a custom user ID.
+
+The useful product metrics are:
+
+| Metric | GA4 interpretation |
+| --- | --- |
+| Visitors | `Total users` or `Active users` across automatically collected events |
+| New browser visitors | `New users`, populated by `first_visit` |
+| Activated calculator users | `Total users` filtered to `calculation_started` |
+| Users who completed a result | `Total users` filtered to `calculation_completed` |
+| Calculation attempts | Event count for `calculation_started` |
+| Completed calculations | Event count for `calculation_completed` |
+
+These are approximate browser/device users, not exact humans. One person using two browsers can count twice, several people sharing one browser can count once, and clearing cookies creates a new client ID. Ad blockers, network failures, consent choices, and disabled cookies reduce the observed count. GA4 can also use modeled or approximate reporting; Google documents HyperLogLog++ for many distinct-count reports. Public claims should therefore use wording such as **measured calculator users** or **browser users**, not “verified unique people.”
+
+GA4 Standard currently permits up to 14 months of event-level retention for Explorations. Standard aggregate reports and user-lifetime surfaces have different behavior and limits. If a durable audited all-time financial metric becomes necessary, export periodic aggregates to an owned reporting system rather than treating a free dashboard as an immutable ledger.
+
+## Runtime flow
+
+```mermaid
+flowchart LR
+    config["VITE_GA_MEASUREMENT_ID"]
+    loader["Load the Google tag"]
+    cookie["GA4 first-party client ID"]
+    page["Automatic page and session events"]
+    start["calculation_started"]
+    complete["calculation_completed"]
+    reports["GA4 reports and Explorations"]
+
+    config --> loader
+    loader --> cookie
+    loader --> page
+    loader --> start
+    start --> complete
+    page --> reports
+    start --> reports
+    complete --> reports
+```
+
+`src/main.tsx` initializes the tag before rendering the application. If the measurement ID is absent or invalid, initialization is a no-op and the application behaves normally. The measurement ID is a public routing identifier, not a secret.
+
+The calculator sends `calculation_started` only after labels and input structure pass validation. It sends `calculation_completed` only after QSearch returns a valid tree. Analytics is fail-open: blocked or unavailable analytics never prevents a local calculation.
+
+## Data contract
+
+Each custom event contains only:
+
+```json
+{
+  "event_name": "calculation_started",
+  "input_kind": "objects",
+  "object_count": 4
+}
+```
+
+`input_kind` is `objects` or `distance-matrix`. `object_count` is the number of compared objects. The Google tag also collects its documented default web fields, including page location, page title, referrer, language, and device/browser information according to the GA4 property settings.
+
+CompLearn does not send labels, accession IDs, filenames, sequence contents, uploaded data, matrices, distances, content hashes, exported experiment data, email addresses, account IDs, or a custom user ID. Do not add high-cardinality run identifiers or scientific-input metadata as event parameters.
+
+The code sets advertising storage, advertising user data, and ad personalization consent to `denied`. It also disables Google Signals and ad-personalization signals in the tag configuration. Analytics storage is `granted` because the requested browser-level user count depends on the first-party client ID.
+
+## Deployment
+
+1. Create a GA4 property and a Web data stream for the production site.
+2. Copy its measurement ID, which has the form `G-XXXXXXXXXX`.
+3. Set the build-time frontend variable:
+
+   ```text
+   VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+   ```
+
+4. Rebuild and deploy the frontend. Vite embeds this public value in the JavaScript bundle.
+5. Visit the deployed site and verify `page_view` and `calculation_started` in Realtime or with Google Tag Assistant.
+6. In GA4 Admin, review data retention, internal-traffic filters, unwanted referrals, granular location/device collection, data sharing, and enhanced measurement.
+
+Local development and CI should normally leave the variable unset so they do not pollute production analytics. Use a separate GA4 property or data stream when end-to-end analytics testing is necessary.
+
+## Dashboard setup
+
+The default GA4 reports show visitors, acquisition, engagement, pages, geography, and technology after the tag begins collecting. Realtime usually appears within minutes; standard report processing can take longer.
+
+For the core activation view, create an Exploration with `Event name` as a dimension and `Total users` plus `Event count` as metrics. Filter event names to `calculation_started` and `calculation_completed`. This separates users who merely visit from users who use the calculator. Optionally mark `calculation_completed` as a key event.
+
+To report the two custom parameters, register `input_kind` as an event-scoped custom dimension and `object_count` as an event-scoped custom metric. GA4 does not retroactively populate newly registered custom definitions, so configure them before relying on those breakdowns.
+
+## Privacy and consent operations
+
+Enabling the measurement ID causes the browser to contact Google and permits analytics storage. Before production enablement, update the public privacy notice with the measurement purpose, provider, fields collected, retention, cookie behavior, opt-out or deletion process, and applicable international-transfer information. Determine whether consent is required for each deployment jurisdiction and integrate a consent-management platform when required. Leaving `VITE_GA_MEASUREMENT_ID` unset is the fail-safe way to ship with no GA collection until that work is complete.
+
+Google Analytics is hosted infrastructure rather than zero-cost ownership. It removes the application database and dashboard maintenance, but it introduces a third-party processor, browser blocking, service limits, policy obligations, and vendor dependence. Access to the GA property should use least privilege and organization-controlled accounts.
+
+Relevant Google documentation:
+
+- [Install the Google tag](https://developers.google.com/tag-platform/gtagjs)
+- [Set up GA4 events](https://developers.google.com/analytics/devguides/collection/ga4/events)
+- [Google tag API and consent fields](https://developers.google.com/tag-platform/gtagjs/reference)
+- [GA4 default data collection](https://support.google.com/analytics/answer/11593727)
+- [GA4 user metrics](https://support.google.com/analytics/answer/12253918)
+- [GA4 configuration limits](https://support.google.com/analytics/answer/12229528)
+
+## Verification
+
+```bash
+cd ncd-calculator
+npm test -- src/__test__/googleAnalytics.test.ts
+npm run lint
+npm run build
+```
+
+The unit test verifies disabled and invalid configuration, one-time tag loading, analytics-only consent defaults, advertising-signal controls, and the exact custom-event allowlist.

--- a/ncd-calculator/src/App.tsx
+++ b/ncd-calculator/src/App.tsx
@@ -11,7 +11,7 @@ import {RouteAccessibility} from "@/components/RouteAccessibility";
 
 function App() {
     const [openLogin, setOpenLogin] = useState(false)
-    const [authenticated, setAuthenticated] = useState(false)
+    const [, setAuthenticated] = useState(false)
     const closeLogin = useCallback((): void => setOpenLogin(false), []);
 
     return (
@@ -33,7 +33,6 @@ function App() {
                         element={
                             <QSearch
                                 setOpenLogin={setOpenLogin}
-                                authenticated={authenticated}
                                 setAuthenticated={setAuthenticated}
                             />
                         }

--- a/ncd-calculator/src/__test__/googleAnalytics.test.ts
+++ b/ncd-calculator/src/__test__/googleAnalytics.test.ts
@@ -1,0 +1,85 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from "vitest";
+
+const loadAnalytics = async () => import("@/services/GoogleAnalytics");
+
+const readDataLayer = (): unknown[][] => (
+    (window.dataLayer ?? []).map(entry => Array.from(entry as ArrayLike<unknown>))
+);
+
+beforeEach(() => {
+    vi.resetModules();
+    delete window.dataLayer;
+    delete window.gtag;
+    document.getElementById("complearn-google-analytics")?.remove();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("Google Analytics usage measurement", () => {
+    test("does nothing when the GA4 measurement ID is absent or invalid", async () => {
+        const {initializeGoogleAnalytics} = await loadAnalytics();
+        const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        expect(initializeGoogleAnalytics(undefined)).toBe(false);
+        expect(initializeGoogleAnalytics("UA-legacy-id")).toBe(false);
+        expect(document.getElementById("complearn-google-analytics")).toBeNull();
+        expect(window.gtag).toBeUndefined();
+        expect(warning).toHaveBeenCalledOnce();
+    });
+
+    test("loads one Google tag with analytics-only consent and privacy controls", async () => {
+        const {initializeGoogleAnalytics} = await loadAnalytics();
+
+        expect(initializeGoogleAnalytics(" g-test123 ")).toBe(true);
+        expect(initializeGoogleAnalytics("G-TEST123")).toBe(true);
+
+        const scripts = document.querySelectorAll("#complearn-google-analytics");
+        expect(scripts).toHaveLength(1);
+        expect((scripts[0] as HTMLScriptElement).src).toBe(
+            "https://www.googletagmanager.com/gtag/js?id=G-TEST123",
+        );
+        expect(readDataLayer()).toEqual([
+            ["consent", "default", {
+                ad_storage: "denied",
+                ad_user_data: "denied",
+                ad_personalization: "denied",
+                analytics_storage: "granted",
+            }],
+            ["js", expect.any(Date)],
+            ["config", "G-TEST123", {
+                allow_google_signals: false,
+                allow_ad_personalization_signals: false,
+                send_page_view: true,
+            }],
+        ]);
+    });
+
+    test("sends only coarse calculation fields to the configured stream", async () => {
+        const {initializeGoogleAnalytics, trackCalculationEvent} = await loadAnalytics();
+        initializeGoogleAnalytics("G-TEST123");
+
+        trackCalculationEvent("calculation_started", {
+            inputKind: "objects",
+            objectCount: 12,
+        });
+        trackCalculationEvent("calculation_completed", {
+            inputKind: "distance-matrix",
+            objectCount: 8,
+        });
+
+        expect(readDataLayer().slice(-2)).toEqual([
+            ["event", "calculation_started", {
+                input_kind: "objects",
+                object_count: 12,
+                send_to: "G-TEST123",
+            }],
+            ["event", "calculation_completed", {
+                input_kind: "distance-matrix",
+                object_count: 8,
+                send_to: "G-TEST123",
+            }],
+        ]);
+    });
+});

--- a/ncd-calculator/src/__test__/workbench.test.tsx
+++ b/ncd-calculator/src/__test__/workbench.test.tsx
@@ -72,6 +72,20 @@ describe("NCD workbench", () => {
         expect(screen.getByLabelText("0 of 4 required objects selected")).toBeInTheDocument();
     });
 
+    test("does not require sign-in for a comparison set larger than 16 objects", () => {
+        const example = getWorkbenchExampleItems()[0];
+        const items = Array.from({length: 17}, (_, index) => ({
+            ...example,
+            id: `large-set-${index}`,
+            label: `Object ${index + 1}`,
+        }));
+
+        render(<InputHolder selectedItems={items} onRemoveItem={vi.fn()} MIN_ITEMS={4}/>);
+
+        expect(screen.getByText("17 objects")).toBeInTheDocument();
+        expect(screen.queryByText(/sign in to prepare/i)).not.toBeInTheDocument();
+    });
+
     test("opens source modes directly at their useful controls", () => {
         render(
             <FastaSearch
@@ -145,8 +159,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -163,8 +175,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -185,8 +195,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -202,8 +210,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={onComputedNcdInput}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -234,8 +240,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={onComputedNcdInput}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );
@@ -266,8 +270,6 @@ describe("NCD workbench", () => {
                     onComputedNcdInput={vi.fn()}
                     setIsLoading={vi.fn()}
                     resetDisplay={vi.fn()}
-                    setOpenLogin={vi.fn()}
-                    authenticated={false}
                 />
             </MemoryRouter>
         );

--- a/ncd-calculator/src/components/InputHolder.tsx
+++ b/ncd-calculator/src/components/InputHolder.tsx
@@ -7,14 +7,12 @@ export interface InputAccumulatorProps {
   MIN_ITEMS?: number;
   selectedItems: SelectedItem[];
   onRemoveItem: (id: string) => void;
-  authenticated?: boolean;
 }
 
 export const InputHolder: React.FC<InputAccumulatorProps> = ({
   MIN_ITEMS = 4,
   selectedItems,
   onRemoveItem,
-  authenticated,
 }) => {
   const items = Array.isArray(selectedItems) ? selectedItems : [];
   const remainingItems = Math.max(MIN_ITEMS - items.length, 0);
@@ -70,11 +68,6 @@ export const InputHolder: React.FC<InputAccumulatorProps> = ({
             <div className="selected-objects__summary" aria-live="polite">
                 <strong>{items.length} {items.length === 1 ? "object" : "objects"}</strong>
                 {remainingItems > 0 && <span>{remainingItems} more needed</span>}
-                {!authenticated && items.length > 16 && (
-                    <p className="selected-objects__limit" role="alert">
-                        Sign in to prepare a set larger than 16 objects.
-                    </p>
-                )}
             </div>
             <div className="selected-objects__progress" aria-label={`${items.length} of ${MIN_ITEMS} required objects selected`}>
                 <span style={{width: `${Math.min((items.length / MIN_ITEMS) * 100, 100)}%`}} />

--- a/ncd-calculator/src/components/ListEditor.tsx
+++ b/ncd-calculator/src/components/ListEditor.tsx
@@ -115,8 +115,6 @@ interface ListEditorProps {
 	onComputedNcdInput: (input: NCDInput) => void;
 	setIsLoading: (loading: boolean) => void;
 	resetDisplay: () => void;
-	setOpenLogin: (open: boolean) => void;
-	authenticated: boolean;
 	initialSearchMode?: SearchMode | null;
 }
 
@@ -322,10 +320,6 @@ const ListEditor: React.FC<ListEditorProps> = ({
 	};
 	
 	const sendNcdInput = async (): Promise<void> => {
-		// if (selectedItems && selectedItems.length > 16 && !authenticated) {
-		// 	setOpenLogin(true);
-		// 	return;
-		// }
 		setImportError(null);
 		setIsLoading(true);
 		try {

--- a/ncd-calculator/src/components/QSearch.tsx
+++ b/ncd-calculator/src/components/QSearch.tsx
@@ -39,17 +39,19 @@ import {
 	serializeClusteringExperimentExport,
 } from "@/services/ClusteringExperimentExport";
 import type {ClusteringExperimentTiming, CompleteCompressionRecords} from "@/types/experiment";
+import {
+	trackCalculationEvent,
+} from "@/services/GoogleAnalytics";
+import type {CalculationAnalyticsContext} from "@/services/GoogleAnalytics";
 import "./Workbench.css";
 
 export interface QSearchProps {
 	setOpenLogin: (open: boolean) => void;
-	authenticated: boolean;
 	setAuthenticated: (auth: boolean) => void;
 }
 
 export const QSearch: React.FC<QSearchProps> = ({
 	                                                setOpenLogin,
-	                                                authenticated,
 	                                                setAuthenticated,
 	                                                }) => {
 	const [ncdMatrix, setNcdMatrix] = useState<number[][]>([]);
@@ -69,6 +71,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 	const [compressionRecords, setCompressionRecords] = useState<CompleteCompressionRecords | null>(null);
 	const [experimentTiming, setExperimentTiming] = useState<ClusteringExperimentTiming | null>(null);
 	const experimentStartedAtRef = useRef<string | null>(null);
+	const calculationAnalyticsRef = useRef<CalculationAnalyticsContext | null>(null);
 	
 	// Add gridObjects state for KGridVisualization
 	const [gridObjects, setGridObjects] = useState<GridObject[]>([]);
@@ -111,10 +114,14 @@ export const QSearch: React.FC<QSearchProps> = ({
 				});
 				setQSearchProgress(null);
 				setIsLoading(false);
+				const analyticsContext = calculationAnalyticsRef.current;
+				calculationAnalyticsRef.current = null;
+				if (analyticsContext) trackCalculationEvent("calculation_completed", analyticsContext);
 			} catch (error) {
 				console.error("Error processing QSearch result:", error);
 				setErrorMsg("QSearch returned an invalid tree result");
 				setIsLoading(false);
+				calculationAnalyticsRef.current = null;
 			}
 		} else if (event.data.action === "qsearchProgress") {
 			setQSearchProgress({
@@ -125,6 +132,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 			setErrorMsg(`Tree search failed: ${event.data.message}`);
 			setQSearchProgress(null);
 			setIsLoading(false);
+			calculationAnalyticsRef.current = null;
 		}
 	};
 	
@@ -160,14 +168,14 @@ export const QSearch: React.FC<QSearchProps> = ({
 			return;
 		}
 		
-		// Check authentication for large computations
-		if (input.contents.length > 16 && !authenticated) {
-			setOpenLogin(true);
-			return;
-		}
-		
 		try {
 			const computationInput: NCDInput = {...input, labels: normalizedLabels};
+			const analyticsContext: CalculationAnalyticsContext = {
+				inputKind: computationInput.kind === "distance-matrix" ? "distance-matrix" : "objects",
+				objectCount: computationInput.contents.length,
+			};
+			calculationAnalyticsRef.current = analyticsContext;
+			trackCalculationEvent("calculation_started", analyticsContext);
 			const startedAt = new Date().toISOString();
 			experimentStartedAtRef.current = startedAt;
 			setCurrentInput(computationInput);
@@ -324,6 +332,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 			console.error("Error in onNcdInput:", error);
 			setErrorMsg(error instanceof Error ? error.message : "Processing failed");
 			setIsLoading(false);
+			calculationAnalyticsRef.current = null;
 		}
 	};
 
@@ -422,6 +431,7 @@ export const QSearch: React.FC<QSearchProps> = ({
 		setCurrentInput(null);
 		setExperimentTiming(null);
 		experimentStartedAtRef.current = null;
+		calculationAnalyticsRef.current = null;
 		setCompressionStats({
 			processedPairs: 0,
 			totalPairs: 0,
@@ -445,8 +455,6 @@ export const QSearch: React.FC<QSearchProps> = ({
 					onComputedNcdInput={onNcdInput}
 					setIsLoading={setIsLoading}
 					resetDisplay={resetDisplay}
-					setOpenLogin={setOpenLogin}
-					authenticated={authenticated}
 				/>
 				
 				{isLoading && (

--- a/ncd-calculator/src/main.tsx
+++ b/ncd-calculator/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import {initializeGoogleAnalytics} from './services/GoogleAnalytics'
+
+initializeGoogleAnalytics()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/ncd-calculator/src/services/GoogleAnalytics.ts
+++ b/ncd-calculator/src/services/GoogleAnalytics.ts
@@ -1,0 +1,98 @@
+export type CalculationAnalyticsEvent = "calculation_started" | "calculation_completed";
+export type CalculationInputKind = "objects" | "distance-matrix";
+
+export interface CalculationAnalyticsContext {
+    readonly inputKind: CalculationInputKind;
+    readonly objectCount: number;
+}
+
+declare global {
+    interface Window {
+        dataLayer?: unknown[];
+        gtag?: (...args: unknown[]) => void;
+    }
+}
+
+const GOOGLE_TAG_SCRIPT_ID = "complearn-google-analytics";
+const MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]+$/;
+
+let configuredMeasurementId: string | null = null;
+
+const normalizeMeasurementId = (value: string | undefined): string | null => {
+    const measurementId = value?.trim().toUpperCase() ?? "";
+    return MEASUREMENT_ID_PATTERN.test(measurementId) ? measurementId : null;
+};
+
+const ensureGoogleTagQueue = (): ((...args: unknown[]) => void) => {
+    window.dataLayer ??= [];
+    window.gtag ??= function googleTagQueue(): void {
+        window.dataLayer?.push(arguments);
+    };
+    return window.gtag;
+};
+
+/**
+ * Loads GA4 only when a valid public measurement ID is configured. Advertising
+ * storage and personalization remain disabled; analytics storage is required
+ * for GA4's first-party client ID and browser-level user counts.
+ */
+export const initializeGoogleAnalytics = (
+    rawMeasurementId: string | undefined = import.meta.env.VITE_GA_MEASUREMENT_ID,
+): boolean => {
+    if (typeof window === "undefined" || typeof document === "undefined") return false;
+
+    const measurementId = normalizeMeasurementId(rawMeasurementId);
+    if (!measurementId) {
+        if (rawMeasurementId?.trim()) console.warn("VITE_GA_MEASUREMENT_ID is not a valid GA4 measurement ID.");
+        return false;
+    }
+    if (configuredMeasurementId === measurementId) return true;
+    if (configuredMeasurementId) {
+        console.warn("Google Analytics is already configured with a different measurement ID.");
+        return false;
+    }
+
+    const gtag = ensureGoogleTagQueue();
+    configuredMeasurementId = measurementId;
+
+    gtag("consent", "default", {
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+        analytics_storage: "granted",
+    });
+    gtag("js", new Date());
+    gtag("config", measurementId, {
+        allow_google_signals: false,
+        allow_ad_personalization_signals: false,
+        send_page_view: true,
+    });
+
+    if (!document.getElementById(GOOGLE_TAG_SCRIPT_ID)) {
+        const script = document.createElement("script");
+        script.id = GOOGLE_TAG_SCRIPT_ID;
+        script.async = true;
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
+        document.head.appendChild(script);
+    }
+
+    return true;
+};
+
+/**
+ * Sends only coarse product-usage fields. Labels, filenames, contents,
+ * matrices, hashes, and a custom user ID are deliberately excluded.
+ */
+export const trackCalculationEvent = (
+    event: CalculationAnalyticsEvent,
+    context: CalculationAnalyticsContext,
+): void => {
+    if (typeof window === "undefined" || !configuredMeasurementId || !window.gtag) return;
+    if (!Number.isSafeInteger(context.objectCount) || context.objectCount < 1) return;
+
+    window.gtag("event", event, {
+        input_kind: context.inputKind,
+        object_count: context.objectCount,
+        send_to: configuredMeasurementId,
+    });
+};

--- a/ncd-calculator/src/vite-env.d.ts
+++ b/ncd-calculator/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
     readonly VITE_BACKEND_BASE_URL?: string;
     readonly VITE_BASE_URL?: string;
     readonly VITE_AUTH_ENABLED?: string;
+    readonly VITE_GA_MEASUREMENT_ID?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- add an opt-in GA4 loader configured by the public `VITE_GA_MEASUREMENT_ID` build variable
- use GA4's first-party client ID and standard user metrics instead of an application analytics database
- record `calculation_started` and `calculation_completed` with only input kind and object count
- remove the 16-object login gate so every local calculation remains available without an account
- disable advertising storage, advertising user data, ad personalization, Google Signals, and ad-personalization signals
- document dashboard setup, counting semantics, privacy/consent operations, GA4 limitations, and the future cloud-identity boundary

This supersedes the database-backed approach in draft PR #176. No backend routes, database models, migrations, metrics tokens, or server analytics infrastructure are included.

## Why

The immediate product need is approximate visitor and activated-calculator user counts with a maintained reporting UI. GA4 Standard provides collection and dashboards without operating an application analytics database.

The meaningful activation metric is `Total users` filtered to `calculation_started`; completed users can be measured with the corresponding completion event. These are approximate browser/device users rather than verified unique humans because cookies can be cleared, one person can use several devices, shared browsers can represent several people, and blockers or consent choices can prevent collection.

## Data and operational impact

- Analytics is disabled when `VITE_GA_MEASUREMENT_ID` is unset or invalid.
- The measurement ID is public and must be embedded at frontend build time.
- GA4 automatically collects its documented default web fields. CompLearn's custom events never include labels, filenames, accessions, scientific contents, matrices, hashes, account IDs, email addresses, or a custom user ID.
- Analytics storage is granted to support GA4's first-party `_ga` client ID; advertising-related consent and signals are denied.
- Production enablement requires an updated privacy notice and any consent mechanism required by the deployment jurisdictions.
- GA's client ID is analytics data, not an authorization credential. Future cloud-save ownership still requires a server-authorized anonymous principal, account, or other recoverable identity.

## Deployment

1. Create a GA4 property and Web data stream.
2. Build the frontend with `VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX`.
3. Verify page and calculation events in Realtime or Google Tag Assistant.
4. Create an Exploration using Event name with Total users and Event count.
5. Optionally register `input_kind` as a custom dimension, `object_count` as a custom metric, and `calculation_completed` as a key event.

The complete runbook is in `ncd-calculator/docs/GOOGLE_ANALYTICS.md`.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- src/__test__/googleAnalytics.test.ts src/__test__/workbench.test.tsx` — 16 passed
- `npm test` — 267 passed
- `git diff --check origin/main...HEAD`

Known baseline: `npm run typecheck` already fails on `main` in unrelated legacy files. It reports no errors in the GA4 service, analytics tests, event wiring, or documentation changes in this PR.
